### PR TITLE
add sync folder items to account model and rename

### DIFF
--- a/exchangelib/account.py
+++ b/exchangelib/account.py
@@ -11,7 +11,7 @@ from future.utils import python_2_unicode_compatible
 from six import string_types
 
 from exchangelib.services import GetUserOofSettings, SetUserOofSettings, SyncFolderHierarchy, Subscribe, \
-    GetStreamingEvents, Unsubscribe
+    GetStreamingEvents, Unsubscribe, SyncFolderItems
 from exchangelib.settings import OofSettings
 from .autodiscover import discover
 from .credentials import DELEGATE, IMPERSONATION, ACCESS_TYPES
@@ -125,6 +125,9 @@ class Account(object):
 
     def unsubscribe_from_notifications(self, subscription_id):
         return Unsubscribe(self, [subscription_id]).call()
+
+    def sync_folder_items(self, folders, shape, sync_state=None, ignore=None, max_changes=100):
+        return SyncFolderItems(account=self, folders=folders).call(shape, sync_state, ignore, max_changes)
 
     @threaded_cached_property
     def admin_audit_logs(self):

--- a/exchangelib/events.py
+++ b/exchangelib/events.py
@@ -200,7 +200,7 @@ EVENT_TYPES = [
     FreeBusyChangedEvent,
 ]
 
-CONCRETE_EVENT_CLASSES = [
+CONCRETE_EVENT_TYPES = [
     FolderCopiedEvent,
     ItemCopiedEvent,
     ItemCreatedEvent,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -42,7 +42,7 @@ from exchangelib.errors import RelativeRedirect, ErrorItemNotFound, ErrorInvalid
     AmbiguousTimeError, NonExistentTimeError, ErrorUnsupportedPathForQuery, ErrorInvalidPropertyForOperation, \
     ErrorInvalidValueForProperty, ErrorPropertyUpdate, ErrorDeleteDistinguishedFolder, \
     ErrorNoPublicFolderReplicaAvailable, ErrorSubscriptionUnsubscribed
-from exchangelib.events import CONCRETE_EVENT_CLASSES
+from exchangelib.events import CONCRETE_EVENT_TYPES
 from exchangelib.ewsdatetime import EWSDateTime, EWSDate, EWSTimeZone, UTC, UTC_NOW
 from exchangelib.extended_properties import ExtendedProperty, ExternId
 from exchangelib.fields import BooleanField, IntegerField, DecimalField, TextField, EmailField, URIField, ChoiceField, \
@@ -2717,7 +2717,7 @@ class FolderTest(EWSTest):
                 assert (change.item.item_id, change.item.changekey) not in changes_seen
 
     def test_streaming_subscription(self):
-        subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_CLASSES)
+        subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_TYPES)
         try:
             for event in self.account.inbox.listen_for_notifications(subscription_id, timeout_s=60):
                 if isinstance(event, ConnectionStatus):
@@ -2732,7 +2732,7 @@ class FolderTest(EWSTest):
         for folder in self.account.root.walk():
             folders.append(folder)
 
-        subscription_id = self.account.subscribe_for_notifications(folders, CONCRETE_EVENT_CLASSES)
+        subscription_id = self.account.subscribe_for_notifications(folders, CONCRETE_EVENT_TYPES)
         try:
             for event in self.account.listen_for_notifications(subscription_id, timeout_s=60):
                 if isinstance(event, ConnectionStatus):
@@ -2743,7 +2743,7 @@ class FolderTest(EWSTest):
             self.account.unsubscribe_from_notifications(subscription_id)
 
     def test_canceling_streaming_subscription(self):
-        subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_CLASSES)
+        subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_TYPES)
         unsubscribed_successfully = False
         caught_exception = False
         try:


### PR DESCRIPTION
Added sync_folder_items to the account model which calls the service SyncFolderItems. Also renamed CONCRETE_EVENT_CLASSES to CONCRETE_EVENT_TYPES.