### PR TITLE
Add IncludesLastItemInRange and optional debugging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dist
 
 settings.yml
 scratch*.py
+
+tags

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -276,6 +276,8 @@ class PrettyXmlHandler(logging.StreamHandler):
     @staticmethod
     def prettify_xml(xml_bytes):
         # Re-formats an XML document to a consistent style
+        if isinstance(xml_bytes, unicode):
+            xml_bytes = xml_bytes.encode('utf-8')
         return tostring(parse(
             io.BytesIO(xml_bytes)),
             xml_declaration=True,


### PR DESCRIPTION
This allows us to know when we're up-to-date for a particular folder by adding the `<IncludesLastItemInRange>` tag to the end of the iterator of `SyncFolderItems`

See https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/includeslastiteminrange

And https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/syncfolderitemsresponsemessage

Even if there are no changes in a folder, the `sync_state` will still change. We need the  `IncludesLastItemInRange` boolean to let us know whether to continue looking for new changes.

`SyncFolderItems` is an iterator that iterates through new changes. When we get to the end of the changes, it used to return a single string `sync_state` as its final item.

This changes the `SyncFolderItems` service to return a new `SyncStateFinish` mini-class instead of the `sync_state` as a string.

Finally, this also adds a new `SAVE_RAW_XML_PATH` os environment flag that will serialize out all requests in a human readable format. This is really useful when debugging what exchangelib is sending back and forth.