### PR TITLE
Fix fields for DeleteFolderChange

### DIFF
--- a/exchangelib/changes.py
+++ b/exchangelib/changes.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from exchangelib.fields import ItemField, FolderField
+from exchangelib.fields import ItemField, FolderField, IdAndChangekeyField
 from exchangelib.properties import EWSElement
 from exchangelib.transport import TNS
 
@@ -48,4 +48,8 @@ class UpdateFolderChange(FolderChange):
 
 
 class DeleteFolderChange(FolderChange):
+    FIELDS = [
+        IdAndChangekeyField('item_id', field_uri='FolderId'),
+    ]
+    __slots__ = ('item_id',)
     ELEMENT_NAME = 'Delete'


### PR DESCRIPTION
As a subclass of FolderChange, DeleteFolderChange was previously looking
for a 'Folder' field when parsing the xml response. However, this field
does not exist for folder deletions. 'FolderId' is the only field
returned. This diff updates DeleteFolderChange to parse the "FolderId"
field into an `item_id` attribute. It takes the form of a raw tuple with
the id and changekey.

See https://docs.microsoft.com/en-us/previous-versions/office/developer/exchange-server-2010/aa565228%28v%3dexchg.140%29