### PR TITLE
Add `addtional_fields` kwarg to `sync_folder_hierarchy()`

### DIFF
--- a/exchangelib/account.py
+++ b/exchangelib/account.py
@@ -119,8 +119,8 @@ class Account(object):
             folders_map[f.__class__].append(f)
         return folders_map
 
-    def sync_folder_hierarchy(self, shape, sync_state=None):
-        return SyncFolderHierarchy(account=self).call(shape, sync_state)
+    def sync_folder_hierarchy(self, shape, sync_state=None, additional_fields=None):
+        return SyncFolderHierarchy(account=self).call(shape, sync_state, additional_fields)
 
     def subscribe_for_notifications(self, folders, event_types):
         return Subscribe(account=self, folders=folders).call(event_types)

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -511,6 +511,26 @@ class EWSService(object):
     def _get_elements_in_container(container):
         return [elem for elem in container]
 
+    def add_additional_properties_to_shape(self, shape_element, additional_fields):
+        if not additional_fields:
+            return
+
+        from .fields import FieldPath
+
+        additional_field_paths = []
+
+        for field in additional_fields:
+            if isinstance(field, FieldPath):
+                field_path = field
+            else:
+                field_path = FieldPath(field=field)
+            additional_field_paths.append(field_path)
+
+        additional_properties = create_element('t:AdditionalProperties')
+        expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_field_paths))
+        set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path), self.account.version)
+        shape_element.append(additional_properties)
+
 
 class EWSAccountService(EWSService):
 
@@ -816,12 +836,7 @@ class GetItem(EWSAccountService, EWSPooledMixIn):
         getitem = create_element('m:%s' % self.SERVICE_NAME)
         itemshape = create_element('m:ItemShape')
         add_xml_child(itemshape, 't:BaseShape', shape)
-        if additional_fields:
-            additional_properties = create_element('t:AdditionalProperties')
-            expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_fields))
-            set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path),
-                          version=self.account.version)
-            itemshape.append(additional_properties)
+        self.add_additional_properties_to_shape(itemshape, additional_fields)
         getitem.append(itemshape)
         item_ids = create_element('m:ItemIds')
         is_empty = True
@@ -1120,12 +1135,7 @@ class FindItem(EWSFolderService, PagingEWSMixIn):
         finditem = create_element('m:%s' % self.SERVICE_NAME, Traversal=depth)
         itemshape = create_element('m:ItemShape')
         add_xml_child(itemshape, 't:BaseShape', shape)
-        if additional_fields:
-            additional_properties = create_element('t:AdditionalProperties')
-            expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_fields))
-            set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path),
-                          version=self.account.version)
-            itemshape.append(additional_properties)
+        self.add_additional_properties_to_shape(itemshape, additional_fields)
         finditem.append(itemshape)
         if calendar_view is None:
             view_type = create_element('m:IndexedPageItemView',
@@ -1182,12 +1192,7 @@ class FindFolder(EWSFolderService, PagingEWSMixIn):
         findfolder = create_element('m:%s' % self.SERVICE_NAME, Traversal=depth)
         foldershape = create_element('m:FolderShape')
         add_xml_child(foldershape, 't:BaseShape', shape)
-        if additional_fields:
-            additional_properties = create_element('t:AdditionalProperties')
-            expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_fields))
-            set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path),
-                          version=self.account.version)
-            foldershape.append(additional_properties)
+        self.add_additional_properties_to_shape(foldershape, additional_fields)
         findfolder.append(foldershape)
         if self.account.version.build >= EXCHANGE_2010:
             indexedpageviewitem = create_element('m:IndexedPageFolderView', MaxEntriesReturned=text_type(page_size),
@@ -1249,12 +1254,7 @@ class GetFolder(EWSAccountService):
         getfolder = create_element('m:%s' % self.SERVICE_NAME)
         foldershape = create_element('m:FolderShape')
         add_xml_child(foldershape, 't:BaseShape', shape)
-        if additional_fields:
-            additional_properties = create_element('t:AdditionalProperties')
-            expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_fields))
-            set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path),
-                          version=self.account.version)
-            foldershape.append(additional_properties)
+        self.add_additional_properties_to_shape(foldershape, additional_fields)
         getfolder.append(foldershape)
         folder_ids = create_element('m:FolderIds')
         is_empty = True
@@ -1403,7 +1403,7 @@ class SyncFolderHierarchy(EWSAccountService):
     SERVICE_NAME = 'SyncFolderHierarchy'
     element_container_name = '{%s}Changes' % MNS
 
-    def call(self, shape, sync_state=None):
+    def call(self, shape, sync_state=None, additional_fields=None):
         from .changes import CreateFolderChange, UpdateFolderChange, DeleteFolderChange
 
         folder_change_classes_by_tag = {
@@ -1412,7 +1412,7 @@ class SyncFolderHierarchy(EWSAccountService):
             DeleteFolderChange.response_tag(): DeleteFolderChange,
         }
 
-        for change in self._get_elements(payload=self.get_payload(shape, sync_state)):
+        for change in self._get_elements(payload=self.get_payload(shape, sync_state, additional_fields)):
             cls = folder_change_classes_by_tag.get(change.tag)
             if not cls:
                 raise ValueError('Unknown Change tag: {}'.format(change.tag))
@@ -1422,10 +1422,11 @@ class SyncFolderHierarchy(EWSAccountService):
         else:
             yield self.sync_state.text
 
-    def get_payload(self, shape, sync_state=None):
+    def get_payload(self, shape, sync_state=None, additional_fields=None):
         sync_folder_hierarchy = create_element('m:%s' % self.SERVICE_NAME)
         foldershape = create_element('m:FolderShape')
         add_xml_child(foldershape, 't:BaseShape', shape)
+        self.add_additional_properties_to_shape(foldershape, additional_fields)
         sync_folder_hierarchy.append(foldershape)
         if sync_state is not None:
             syncstate = create_element('m:SyncState')

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2222,6 +2222,17 @@ class AccountTest(EWSTest):
         for change in self.account.sync_folder_hierarchy(shape='AllProperties', sync_state=sync_state):
             assert not isinstance(change, Change)
 
+    def test_sync_folder_hierarchy_with_additional_fields(self):
+        parent_folder_id_field = Folder.get_field_by_fieldname('parent_folder_id')
+        for change in self.account.sync_folder_hierarchy(shape='IdOnly', additional_fields=[parent_folder_id_field]):
+            if isinstance(change, FolderChange):
+                assert change.folder is not None
+                assert change.folder.id is not None
+                assert change.folder.parent_folder_id is not None
+                # Check that an attribute that would normally be returned with the
+                # 'Default' shape isn't returned in this scenario
+                assert change.folder.total_count is None
+
 
 class AutodiscoverTest(EWSTest):
     def test_magic(self):


### PR DESCRIPTION
This diff consolidates existing code that deals with `addtional_fields`
into a `add_additional_properties_to_shape()` helper method and adds
that functionality to the SyncFolderHierarchy service.