### PR TITLE
Fix fields for DeleteItemChange

### DIFF
--- a/exchangelib/changes.py
+++ b/exchangelib/changes.py
@@ -26,6 +26,10 @@ class UpdateItemChange(ItemChange):
 
 class DeleteItemChange(ItemChange):
     ELEMENT_NAME = 'Delete'
+    FIELDS = [
+        IdAndChangekeyField('item_id', field_uri='ItemId'),
+    ]
+    __slots__ = ('item_id',)
 
 
 class ReadFlagChange(ItemChange):


### PR DESCRIPTION
EWS sends deletes with an ItemId, not an Item. The fields on
DeleteItemChange need to specify the ItemId field to parse it correctly.