### PR TITLE
Avoid referencing log_vals if it hasn't been created

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ dist
 
 settings.yml
 scratch*.py
+
+tags

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+venv/
+.pytest_cache/
 .eggs
 .idea
 .coverage

--- a/exchangelib/account.py
+++ b/exchangelib/account.py
@@ -370,7 +370,7 @@ class Account(object):
             ))
         if folder is not None:
             if not isinstance(folder, Folder):
-                raise ValueError("'folder' %r must be a Folder instence" % folder)
+                raise ValueError("'folder' %r must be a Folder instance" % folder)
             if folder.account != self:
                 raise ValueError('"Folder must belong to this account')
         if message_disposition == SAVE_ONLY and folder is None:
@@ -556,7 +556,7 @@ class Account(object):
         :return: Status for each send operation, in the same order as the input
         """
         if not isinstance(to_folder, Folder):
-            raise ValueError("'to_folder' %r must be a Folder instence" % to_folder)
+            raise ValueError("'to_folder' %r must be a Folder instance" % to_folder)
         # 'ids' could be an unevaluated QuerySet, e.g. if we ended up here via `bulk_copy(some_folder.filter(...))`. In
         # that case, we want to use its iterator. Otherwise, peek() will start a count() which is wasteful because we
         # need the item IDs immediately afterwards. iterator() will only do the bare minimum.
@@ -582,7 +582,7 @@ class Account(object):
         folder in a different mailbox, an empty list is returned.
         """
         if not isinstance(to_folder, Folder):
-            raise ValueError("'to_folder' %r must be a Folder instence" % to_folder)
+            raise ValueError("'to_folder' %r must be a Folder instance" % to_folder)
         # 'ids' could be an unevaluated QuerySet, e.g. if we ended up here via `bulk_move(some_folder.filter(...))`. In
         # that case, we want to use its iterator. Otherwise, peek() will start a count() which is wasteful because we
         # need the item IDs immediately afterwards. iterator() will only do the bare minimum.

--- a/exchangelib/account.py
+++ b/exchangelib/account.py
@@ -11,7 +11,7 @@ from future.utils import python_2_unicode_compatible
 from six import string_types
 
 from exchangelib.services import GetUserOofSettings, SetUserOofSettings, SyncFolderHierarchy, Subscribe, \
-    GetStreamingEvents, Unsubscribe
+    GetStreamingEvents, Unsubscribe, SyncFolderItems
 from exchangelib.settings import OofSettings
 from .autodiscover import discover
 from .credentials import DELEGATE, IMPERSONATION, ACCESS_TYPES
@@ -131,6 +131,9 @@ class Account(object):
 
     def unsubscribe_from_notifications(self, subscription_id):
         return Unsubscribe(self, [subscription_id]).call()
+
+    def sync_folder_items(self, folders, shape, sync_state=None, ignore=None, max_changes=100):
+        return SyncFolderItems(account=self, folders=folders).call(shape, sync_state, ignore, max_changes)
 
     @threaded_cached_property
     def admin_audit_logs(self):

--- a/exchangelib/account.py
+++ b/exchangelib/account.py
@@ -9,7 +9,7 @@ from cached_property import threaded_cached_property
 from future.utils import python_2_unicode_compatible
 from six import string_types
 
-from exchangelib.services import GetUserOofSettings, SetUserOofSettings
+from exchangelib.services import GetUserOofSettings, SetUserOofSettings, SyncFolderHierarchy
 from exchangelib.settings import OofSettings
 from .autodiscover import discover
 from .credentials import DELEGATE, IMPERSONATION, ACCESS_TYPES
@@ -116,6 +116,9 @@ class Account(object):
         for f in self.root.walk():
             folders_map[f.__class__].append(f)
         return folders_map
+
+    def sync_folder_hierarchy(self, shape, sync_state=None):
+        return SyncFolderHierarchy(account=self).call(shape, sync_state)
 
     @threaded_cached_property
     def admin_audit_logs(self):

--- a/exchangelib/account.py
+++ b/exchangelib/account.py
@@ -119,8 +119,8 @@ class Account(object):
             folders_map[f.__class__].append(f)
         return folders_map
 
-    def sync_folder_hierarchy(self, shape, sync_state=None):
-        return SyncFolderHierarchy(account=self).call(shape, sync_state)
+    def sync_folder_hierarchy(self, shape, sync_state=None, additional_fields=None):
+        return SyncFolderHierarchy(account=self).call(shape, sync_state, additional_fields)
 
     def subscribe_for_notifications(self, folders, event_types):
         return Subscribe(account=self, folders=folders).call(event_types)

--- a/exchangelib/changes.py
+++ b/exchangelib/changes.py
@@ -1,0 +1,52 @@
+from __future__ import unicode_literals
+
+from exchangelib import Folder
+from exchangelib.fields import EWSElementField, ItemField, FolderField
+from exchangelib.properties import EWSElement
+from exchangelib.transport import TNS
+
+
+class Change(EWSElement):
+    NAMESPACE = TNS
+
+
+class ItemChange(Change):
+    FIELDS = [
+        ItemField('item'),
+    ]
+    __slots__ = ('item',)
+
+
+class CreateItemChange(ItemChange):
+    ELEMENT_NAME = 'Create'
+
+
+class UpdateItemChange(ItemChange):
+    ELEMENT_NAME = 'Update'
+
+
+class DeleteItemChange(ItemChange):
+    ELEMENT_NAME = 'Delete'
+
+
+class ReadFlagChange(ItemChange):
+    ELEMENT_NAME = 'ReadFlagChange'
+
+
+class FolderChange(Change):
+    FIELDS = [
+        FolderField('folder'),
+    ]
+    __slots__ = ('folder',)
+
+
+class CreateFolderChange(FolderChange):
+    ELEMENT_NAME = 'Create'
+
+
+class UpdateFolderChange(FolderChange):
+    ELEMENT_NAME = 'Update'
+
+
+class DeleteFolderChange(FolderChange):
+    ELEMENT_NAME = 'Delete'

--- a/exchangelib/changes.py
+++ b/exchangelib/changes.py
@@ -26,6 +26,10 @@ class UpdateItemChange(ItemChange):
 
 class DeleteItemChange(ItemChange):
     ELEMENT_NAME = 'Delete'
+    FIELDS = [
+        IdAndChangekeyField('item_id', field_uri='ItemId'),
+    ]
+    __slots__ = ('item_id',)
 
 
 class ReadFlagChange(ItemChange):

--- a/exchangelib/changes.py
+++ b/exchangelib/changes.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from exchangelib.fields import ItemField, FolderField
+from exchangelib.fields import ItemField, FolderField, IdAndChangekeyField
 from exchangelib.properties import EWSElement
 from exchangelib.transport import TNS
 
@@ -48,4 +48,8 @@ class UpdateFolderChange(FolderChange):
 
 
 class DeleteFolderChange(FolderChange):
+    FIELDS = [
+        IdAndChangekeyField('item_id', field_uri='FolderId'),
+    ]
+    __slots__ = ('item_id',)
     ELEMENT_NAME = 'Delete'

--- a/exchangelib/changes.py
+++ b/exchangelib/changes.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
-from exchangelib import Folder
-from exchangelib.fields import EWSElementField, ItemField, FolderField
+from exchangelib.fields import ItemField, FolderField
 from exchangelib.properties import EWSElement
 from exchangelib.transport import TNS
 

--- a/exchangelib/errors.py
+++ b/exchangelib/errors.py
@@ -478,7 +478,7 @@ class ErrorSubmissionQuotaExceeded(ResponseMessageError): pass
 class ErrorSubscriptionAccessDenied(ResponseMessageError): pass
 class ErrorSubscriptionDelegateAccessNotSupported(ResponseMessageError): pass
 class ErrorSubscriptionNotFound(ResponseMessageError): pass
-class ErrorSubscriptionUnsubsribed(ResponseMessageError): pass
+class ErrorSubscriptionUnsubscribed(ResponseMessageError): pass
 class ErrorSyncFolderNotFound(ResponseMessageError): pass
 class ErrorTimeIntervalTooBig(ResponseMessageError): pass
 class ErrorTimeoutExpired(ResponseMessageError): pass

--- a/exchangelib/events.py
+++ b/exchangelib/events.py
@@ -1,0 +1,217 @@
+from __future__ import unicode_literals
+
+from xml.etree.ElementTree import Element
+
+from typing import List
+
+from exchangelib.fields import DateTimeField, IdField, Field, IntegerField, TextField, IdAndChangekeyField
+from exchangelib.properties import EWSElement
+from exchangelib.transport import TNS
+
+
+class Event(EWSElement):
+    ELEMENT_NAME = 'Event'
+    NAMESPACE = TNS
+
+    @classmethod
+    def has_all_required_xml_fields(cls, elem):
+        # type: (Element) -> bool
+        for f in cls.FIELDS:
+            if elem.find(f.response_tag()) is None and f.is_required:
+                return False
+        return True
+
+
+class CopiedEvent(Event):
+    ELEMENT_NAME = 'CopiedEvent'
+    FIELDS = [  # type: List[Field]
+        TextField('watermark', field_uri='Watermark', is_required=False),
+        DateTimeField('timestamp', field_uri='TimeStamp'),
+        IdAndChangekeyField('parent_folder_id', field_uri='ParentFolderId', is_attribute=False),
+        IdAndChangekeyField('old_parent_folder_id', field_uri='OldParentFolderId', is_attribute=False)
+    ]
+    __slots__ = ('watermark', 'timestamp', 'parent_folder_id', 'old_folder_id')
+
+
+class FolderCopiedEvent(CopiedEvent):
+    FIELDS = CopiedEvent.FIELDS + [
+        IdAndChangekeyField('folder_id', field_uri='FolderId', is_required=True, is_attribute=False),
+        IdAndChangekeyField('old_folder_id', field_uri='OldFolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = CopiedEvent.__slots__ + ('folder_id', 'old_folder_id')
+
+
+class ItemCopiedEvent(CopiedEvent):
+    FIELDS = CopiedEvent.FIELDS + [
+        IdAndChangekeyField('item_id', field_uri='ItemId', is_required=True, is_attribute=False),
+        IdAndChangekeyField('old_item_id', field_uri='OldItemId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = CopiedEvent.__slots__ + ('item_id', 'old_item_id')
+
+
+class CreatedEvent(Event):
+    ELEMENT_NAME = 'CreatedEvent'
+    FIELDS = [  # type: List[Field]
+        TextField('watermark', field_uri='Watermark', is_required=False),
+        DateTimeField('timestamp', field_uri='TimeStamp'),
+        IdAndChangekeyField('parent_folder_id', field_uri='ParentFolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = ('watermark', 'timestamp', 'parent_folder_id')
+
+
+class ItemCreatedEvent(CreatedEvent):
+    FIELDS = CreatedEvent.FIELDS + [
+        IdAndChangekeyField('item_id', field_uri='ItemId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = CreatedEvent.__slots__ + ('item_id',)
+
+
+class FolderCreatedEvent(CreatedEvent):
+    FIELDS = CreatedEvent.FIELDS + [
+        IdAndChangekeyField('folder_id', field_uri='FolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = CreatedEvent.__slots__ + ('folder_id',)
+
+
+class DeletedEvent(Event):
+    ELEMENT_NAME = 'DeletedEvent'
+    FIELDS = [  # type: List[Field]
+        TextField('watermark', field_uri='Watermark', is_required=False),
+        DateTimeField('timestamp', field_uri='TimeStamp'),
+        IdAndChangekeyField('parent_folder_id', field_uri='ParentFolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = ('watermark', 'timestamp', 'parent_folder_id')
+
+
+class ItemDeletedEvent(DeletedEvent):
+    FIELDS = DeletedEvent.FIELDS + [
+        IdAndChangekeyField('item_id', field_uri='ItemId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = DeletedEvent.__slots__ + ('item_id',)
+
+
+class FolderDeletedEvent(DeletedEvent):
+    FIELDS = DeletedEvent.FIELDS + [
+        IdAndChangekeyField('folder_id', field_uri='FolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = DeletedEvent.__slots__ + ('folder_id',)
+
+
+class ModifiedEvent(Event):
+    ELEMENT_NAME = 'ModifiedEvent'
+    FIELDS = [  # type: List[Field]
+        TextField('watermark', field_uri='Watermark', is_required=False),
+        DateTimeField('timestamp', field_uri='TimeStamp'),
+        IdAndChangekeyField('parent_folder_id', field_uri='ParentFolderId', is_required=True, is_attribute=False),
+        IntegerField('unread_count', field_uri='UnreadCount', is_read_only=True),
+    ]
+    __slots__ = ('watermark', 'timestamp', 'parent_folder_id', 'unread_count')
+
+
+class ItemModifiedEvent(ModifiedEvent):
+    FIELDS = ModifiedEvent.FIELDS + [
+        IdAndChangekeyField('item_id', field_uri='ItemId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = ModifiedEvent.__slots__ + ('item_id',)
+
+
+class FolderModifiedEvent(ModifiedEvent):
+    FIELDS = ModifiedEvent.FIELDS + [
+        IdAndChangekeyField('folder_id', field_uri='FolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = ModifiedEvent.__slots__ + ('folder_id',)
+
+
+class MovedEvent(Event):
+    ELEMENT_NAME = 'MovedEvent'
+    FIELDS = [  # type: List[Field]
+        TextField('watermark', field_uri='Watermark', is_required=False),
+        DateTimeField('timestamp', field_uri='TimeStamp'),
+        IdAndChangekeyField('parent_folder_id', field_uri='ParentFolderId', is_required=True, is_attribute=False),
+        IdAndChangekeyField('old_parent_folder_id', field_uri='OldParentFolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = ('watermark', 'timestamp', 'parent_folder_id', 'old_parent_folder_id')
+
+
+class ItemMovedEvent(MovedEvent):
+    FIELDS = MovedEvent.FIELDS + [
+        IdAndChangekeyField('item_id', field_uri='ItemId', is_required=True, is_attribute=False),
+        IdAndChangekeyField('old_item_id', field_uri='OldItemId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = MovedEvent.__slots__ + ('item_id', 'old_item_id')
+
+
+class FolderMovedEvent(MovedEvent):
+    FIELDS = MovedEvent.FIELDS + [
+        IdAndChangekeyField('folder_id', field_uri='FolderId', is_required=True, is_attribute=False),
+        IdAndChangekeyField('old_folder_id', field_uri='OldFolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = MovedEvent.__slots__ + ('folder_id', 'old_folder_id')
+
+
+class NewMailEvent(Event):
+    ELEMENT_NAME = 'NewMailEvent'
+    FIELDS = [
+        TextField('watermark', field_uri='Watermark', is_required=False),
+        DateTimeField('timestamp', field_uri='TimeStamp'),
+        IdAndChangekeyField('item_id', field_uri='ItemId', is_required=True, is_attribute=False),
+        IdAndChangekeyField('parent_folder_id', field_uri='ParentFolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = ('watermark', 'timestamp', 'item_id', 'parent_folder_id')
+
+
+class StatusEvent(Event):
+    ELEMENT_NAME = 'StatusEvent'
+    FIELDS = [
+        TextField('watermark', field_uri='Watermark', is_required=False),
+    ]
+    __slots__ = ('watermark',)
+
+
+class FreeBusyChangedEvent(Event):
+    ELEMENT_NAME = 'FreeBusyChangedEvent'
+    FIELDS = [
+        TextField('watermark', field_uri='Watermark', is_required=False),
+        DateTimeField('timestamp', field_uri='TimeStamp'),
+        IdAndChangekeyField('item_id', field_uri='ItemId', is_required=True, is_attribute=False),
+        IdAndChangekeyField('parent_folder_id', field_uri='ParentFolderId', is_required=True, is_attribute=False),
+    ]
+    __slots__ = ('watermark', 'timestamp', 'item_id', 'parent_folder_id')
+
+
+EVENT_TYPES = [
+    CopiedEvent,
+    FolderCopiedEvent,
+    ItemCopiedEvent,
+    CreatedEvent,
+    ItemCreatedEvent,
+    FolderCreatedEvent,
+    DeletedEvent,
+    ItemDeletedEvent,
+    FolderDeletedEvent,
+    ModifiedEvent,
+    ItemModifiedEvent,
+    FolderModifiedEvent,
+    MovedEvent,
+    ItemMovedEvent,
+    FolderMovedEvent,
+    NewMailEvent,
+    StatusEvent,
+    FreeBusyChangedEvent,
+]
+
+CONCRETE_EVENT_CLASSES = [
+    FolderCopiedEvent,
+    ItemCopiedEvent,
+    ItemCreatedEvent,
+    FolderCreatedEvent,
+    ItemDeletedEvent,
+    FolderDeletedEvent,
+    ItemModifiedEvent,
+    FolderModifiedEvent,
+    ItemMovedEvent,
+    FolderMovedEvent,
+    NewMailEvent,
+    StatusEvent,
+    FreeBusyChangedEvent,
+]

--- a/exchangelib/events.py
+++ b/exchangelib/events.py
@@ -200,7 +200,7 @@ EVENT_TYPES = [
     FreeBusyChangedEvent,
 ]
 
-CONCRETE_EVENT_CLASSES = [
+CONCRETE_EVENT_TYPES = [
     FolderCopiedEvent,
     ItemCopiedEvent,
     ItemCreatedEvent,

--- a/exchangelib/ewsdatetime.py
+++ b/exchangelib/ewsdatetime.py
@@ -100,7 +100,7 @@ class EWSDateTime(datetime.datetime):
 
     @classmethod
     def from_datetime(cls, d):
-        if d.__class__ != datetime.datetime:
+        if type(d) != datetime.datetime:
             raise ValueError("%r must be a datetime instance" % d)
         if d.tzinfo is None:
             tz = None

--- a/exchangelib/fields.py
+++ b/exchangelib/fields.py
@@ -6,6 +6,7 @@ import binascii
 import datetime
 from decimal import Decimal, InvalidOperation
 import logging
+from xml.etree.ElementTree import Element
 
 from six import string_types
 
@@ -658,6 +659,18 @@ class IdField(CharField):
         self.is_attribute = True
 
 
+class IdAndChangekeyField(FieldURIField):
+    def from_xml(self, elem, account):
+        result = elem.find(self.response_tag()) # type: Element
+        if result is None and self.is_required:
+            raise ValueError("'%s' missing" % self.response_tag())
+        elem_id = result.get('Id')
+        elem_changekey = result.get('ChangeKey')
+        if elem_id is None:
+            raise ValueError("'%s' is missing 'Id'" % self.response_tag())
+        return elem_id, elem_changekey
+
+
 class CharListField(CharField):
     is_list = True
 
@@ -1200,6 +1213,23 @@ class FolderField(FieldURIField):
                 return folder_cls.from_xml(elem=folder_elem, account=account)
             classes_to_check.extend(folder_cls.__subclasses__())
         return None
+
+
+class EventListField(FieldURIField):
+    is_list = True
+
+    def from_xml(self, elem, account):
+        from .events import CONCRETE_EVENT_CLASSES
+        results = []
+        for event_cls in CONCRETE_EVENT_CLASSES:
+            event_elems = elem.findall(event_cls.response_tag())
+            for e in event_elems:
+                # We can't distinguish between Item*Event and Folder*Event
+                # by tag, only by the fields they have.
+                if not event_cls.has_all_required_xml_fields(e):
+                    continue
+                results.append(event_cls.from_xml(e, account))
+        return results
 
 
 class EffectiveRightsField(EWSElementField):

--- a/exchangelib/fields.py
+++ b/exchangelib/fields.py
@@ -1219,9 +1219,9 @@ class EventListField(FieldURIField):
     is_list = True
 
     def from_xml(self, elem, account):
-        from .events import CONCRETE_EVENT_CLASSES
+        from .events import CONCRETE_EVENT_TYPES
         results = []
-        for event_cls in CONCRETE_EVENT_CLASSES:
+        for event_cls in CONCRETE_EVENT_TYPES:
             event_elems = elem.findall(event_cls.response_tag())
             for e in event_elems:
                 # We can't distinguish between Item*Event and Folder*Event

--- a/exchangelib/fields.py
+++ b/exchangelib/fields.py
@@ -1184,6 +1184,24 @@ class ItemField(FieldURIField):
         return value.to_xml(version=version)
 
 
+class FolderField(FieldURIField):
+    @property
+    def value_cls(self):
+        from .folders import Folder
+        return Folder
+
+    def from_xml(self, elem, account):
+        from .folders import Folder
+        classes_to_check = [Folder]
+        while len(classes_to_check) > 0:
+            folder_cls = classes_to_check.pop()
+            folder_elem = elem.find(folder_cls.response_tag())
+            if folder_elem is not None:
+                return folder_cls.from_xml(elem=folder_elem, account=account)
+            classes_to_check.extend(folder_cls.__subclasses__())
+        return None
+
+
 class EffectiveRightsField(EWSElementField):
     def __init__(self, *args, **kwargs):
         from .properties import EffectiveRights

--- a/exchangelib/folders.py
+++ b/exchangelib/folders.py
@@ -840,8 +840,8 @@ class Folder(RegisterMixIn, SearchableMixIn):
         folder = folders[0]
         if isinstance(folder, Exception):
             raise folder
-        if type(folder) != cls:
-            raise ValueError("Expected 'folder' %r to be a %s instance" % (folder, cls))
+        if not isinstance(folder, cls):
+            raise ValueError("'folder' %r must be a %s instance" % (folder, cls))
         return folder
 
     def refresh(self):

--- a/exchangelib/folders.py
+++ b/exchangelib/folders.py
@@ -1064,6 +1064,7 @@ class Calendar(Folder):
     """
     An interface for the Exchange calendar
     """
+    ELEMENT_NAME = 'CalendarFolder'
     DISTINGUISHED_FOLDER_ID = 'calendar'
     CONTAINER_CLASS = 'IPF.Appointment'
     supported_item_models = (CalendarItem,)
@@ -1181,6 +1182,7 @@ class JunkEmail(Messages):
 
 
 class Tasks(Folder):
+    ELEMENT_NAME = 'TasksFolder'
     DISTINGUISHED_FOLDER_ID = 'tasks'
     CONTAINER_CLASS = 'IPF.Task'
     supported_item_models = (Task,)
@@ -1198,6 +1200,7 @@ class Tasks(Folder):
 
 
 class Contacts(Folder):
+    ELEMENT_NAME = 'ContactsFolder'
     DISTINGUISHED_FOLDER_ID = 'contacts'
     CONTAINER_CLASS = 'IPF.Contact'
     supported_item_models = (Contact, DistributionList)

--- a/exchangelib/folders.py
+++ b/exchangelib/folders.py
@@ -20,7 +20,8 @@ from .items import Item, CalendarItem, Contact, Message, Task, MeetingRequest, M
 from .properties import ItemId, Mailbox, EWSElement, ParentFolderId
 from .queryset import QuerySet, SearchableMixIn
 from .restriction import Restriction
-from .services import FindFolder, GetFolder, FindItem, CreateFolder, UpdateFolder, DeleteFolder, EmptyFolder, FindPeople
+from .services import FindFolder, GetFolder, FindItem, CreateFolder, UpdateFolder, DeleteFolder, EmptyFolder, FindPeople, \
+    SyncFolderItems
 from .transport import TNS, MNS
 from .version import EXCHANGE_2007_SP1, EXCHANGE_2010_SP1, EXCHANGE_2013, EXCHANGE_2013_SP1
 
@@ -651,6 +652,9 @@ class Folder(RegisterMixIn, SearchableMixIn):
             if isinstance(p, Exception):
                 raise p
             yield p
+
+    def sync_folder_items(self, shape, sync_state=None, ignore=None, max_changes=100):
+        return SyncFolderItems(self.account, folders=[self]).call(shape, sync_state, ignore)
 
     def bulk_create(self, items, *args, **kwargs):
         return self.account.bulk_create(folder=self, items=items, *args, **kwargs)

--- a/exchangelib/folders.py
+++ b/exchangelib/folders.py
@@ -6,6 +6,8 @@ import logging
 from operator import attrgetter
 import warnings
 
+import math
+
 from cached_property import threaded_cached_property
 from future.utils import python_2_unicode_compatible
 from six import text_type, string_types
@@ -21,7 +23,7 @@ from .properties import ItemId, Mailbox, EWSElement, ParentFolderId
 from .queryset import QuerySet, SearchableMixIn
 from .restriction import Restriction
 from .services import FindFolder, GetFolder, FindItem, CreateFolder, UpdateFolder, DeleteFolder, EmptyFolder, FindPeople, \
-    SyncFolderItems
+    SyncFolderItems, Subscribe, Unsubscribe, GetStreamingEvents
 from .transport import TNS, MNS
 from .version import EXCHANGE_2007_SP1, EXCHANGE_2010_SP1, EXCHANGE_2013, EXCHANGE_2013_SP1
 
@@ -654,7 +656,17 @@ class Folder(RegisterMixIn, SearchableMixIn):
             yield p
 
     def sync_folder_items(self, shape, sync_state=None, ignore=None, max_changes=100):
-        return SyncFolderItems(self.account, folders=[self]).call(shape, sync_state, ignore)
+        return SyncFolderItems(account=self.account, folders=[self]).call(shape, sync_state, ignore, max_changes)
+
+    def subscribe_for_notifications(self, event_types):
+        return Subscribe(account=self.account, folders=[self]).call(event_types)
+
+    def listen_for_notifications(self, subscription_id, timeout_s=30*60):
+        timeout_minutes = int(math.ceil(float(timeout_s) / 60.0))
+        return GetStreamingEvents(self.account, [subscription_id]).call(timeout_minutes)
+
+    def unsubscribe_from_notifications(self, subscription_id):
+        return Unsubscribe(self.account, [subscription_id]).call()
 
     def bulk_create(self, items, *args, **kwargs):
         return self.account.bulk_create(folder=self, items=items, *args, **kwargs)

--- a/exchangelib/notifications.py
+++ b/exchangelib/notifications.py
@@ -1,0 +1,26 @@
+from __future__ import unicode_literals
+
+from exchangelib.fields import TextField, BooleanField, SubField, EventListField
+from exchangelib.properties import EWSElement
+from exchangelib.transport import TNS, MNS
+
+
+class Notification(EWSElement):
+    ELEMENT_NAME = 'Notification'
+    FIELDS = [
+        TextField('subscription_id', field_uri='SubscriptionId'),
+        TextField('previous_watermark', field_uri='PreviousWatermark'),
+        BooleanField('more_events', field_uri='MoreEvents'),
+        EventListField('events'),
+    ]
+    NAMESPACE = MNS
+    __slots__ = ('subscription_id', 'previous_watermark', 'more_events', 'events')
+
+
+class ConnectionStatus(EWSElement):
+    ELEMENT_NAME = 'ConnectionStatus'
+    NAMESPACE = MNS
+    FIELDS = [
+        SubField('status'),
+    ]
+    __slots__ = ('status',)

--- a/exchangelib/properties.py
+++ b/exchangelib/properties.py
@@ -672,3 +672,8 @@ class FailedMailbox(EWSElement):
     ]
 
     __slots__ = tuple(f.name for f in FIELDS)
+
+
+class SyncState(EWSElement):
+    ELEMENT_NAME = 'SyncState'
+    NAMESPACE = MNS

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -1481,7 +1481,7 @@ class Subscribe(EWSFolderService):
         raise ValueError('No valid response')
 
     def get_payload(self, folders, event_types):
-        from .events import CONCRETE_EVENT_CLASSES
+        from .events import CONCRETE_EVENT_TYPES
 
         subscription = create_element('m:Subscribe')
         streaming_request = create_element('m:StreamingSubscriptionRequest')
@@ -1499,7 +1499,7 @@ class Subscribe(EWSFolderService):
         # we currently don't filter them out during GetStreamingEvents
         # because they map to the same element tag name.
         for event_type in event_types:
-            assert event_type in CONCRETE_EVENT_CLASSES
+            assert event_type in CONCRETE_EVENT_TYPES
             deduped_event_types.add(event_type.ELEMENT_NAME)
 
         for event_type_name in deduped_event_types:

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -59,6 +59,36 @@ class EWSService(object):
     WARNINGS_TO_CATCH_IN_RESPONSE = ErrorBatchProcessingStopped
     # Define the warnings we want to ignore, to let response processing proceed
     WARNINGS_TO_IGNORE_IN_RESPONSE = ()
+    # These are known and understood, and don't require a backtrace.
+    # TODO: ErrorTooManyObjectsOpened means there are too many connections to the database.
+    # We should be able to act on this by lowering the self.protocol connection pool size.
+    ERRORS_TO_CATCH_AND_RERAISE = (
+        ErrorAccessDenied,
+        ErrorADUnavailable,
+        ErrorBatchProcessingStopped,
+        ErrorCannotDeleteObject,
+        ErrorConnectionFailed,
+        ErrorCreateItemAccessDenied,
+        ErrorFolderNotFound,
+        ErrorImpersonateUserDenied,
+        ErrorImpersonationFailed,
+        ErrorInternalServerError,
+        ErrorInternalServerTransientError,
+        ErrorInvalidChangeKey,
+        ErrorInvalidLicense,
+        ErrorItemNotFound,
+        ErrorMailboxMoveInProgress,
+        ErrorMailboxStoreUnavailable,
+        ErrorNonExistentMailbox,
+        ErrorNoPublicFolderReplicaAvailable,
+        ErrorNoRespondingCASInDestinationSite,
+        ErrorQuotaExceeded,
+        ErrorServerBusy,
+        ErrorTimeoutExpired,
+        ErrorTooManyObjectsOpened,
+        RateLimitError,
+        UnauthorizedError,
+    )
 
     def __init__(self, protocol, chunk_size=None):
         self.chunk_size = chunk_size or CHUNK_SIZE  # The number of items to send in a single request
@@ -79,7 +109,7 @@ class EWSService(object):
     # def get_payload(self, **kwargs):
     #     raise NotImplementedError()
 
-    def _get_elements(self, payload):
+    def _get_elements(self, payload, headers=None):
         if not isinstance(payload, ElementType):
             raise ValueError("'payload' %r must be an ElementType" % payload)
         while True:
@@ -134,22 +164,103 @@ class EWSService(object):
                             account, traceback.format_exc(20))
                 raise
 
-    def _get_response_xml(self, payload):
-        # Takes an XML tree and returns SOAP payload as an XML tree
+    def _stream_elements(self, payload, timeout, headers=None):
         if not isinstance(payload, ElementType):
             raise ValueError("'payload' %r must be an ElementType" % payload)
+        try:
+            # Send the request, get the response and do basic sanity checking on the SOAP XML
+            for response in self._stream_response_xml(payload=payload, timeout=timeout, headers=headers):
+                # Read the XML and throw any SOAP or general EWS error messages.
+                # Return a generator over the result elements.
+                for elem in self._get_elements_in_response(response=response):
+                    yield elem
+        except self.ERRORS_TO_CATCH_AND_RERAISE:
+            raise
+        except Exception:
+            # This may run from a thread pool, which obfuscates the stack trace. Print trace immediately.
+            account = self.account if isinstance(self, EWSAccountService) else None
+            log.warning('EWS %s, account %s: Exception in _get_elements: %s', self.protocol.service_endpoint, account,
+                        traceback.format_exc(20))
+            raise
+
+    def _get_account_and_version_hint(self):
         # Microsoft really doesn't want to make our lives easy. The server may report one version in our initial version
         # guessing tango, but then the server may decide that any arbitrary legacy backend server may actually process
         # the request for an account. Prepare to handle ErrorInvalidSchemaVersionForMailboxVersion errors and set the
         # server version per-account.
-        from .version import API_VERSIONS
         if isinstance(self, EWSAccountService):
-            account = self.account
-            hint = self.account.version
+            return self.account, self.account.version
         else:
-            account = None
-            hint = self.protocol.version
-        api_versions = [hint.api_version] + [v for v in API_VERSIONS if v != hint.api_version]
+            return None, self.protocol.version
+
+    def _get_versions_to_try(self, hint):
+        from .version import API_VERSIONS
+        return [hint.api_version] + [v for v in API_VERSIONS if v != hint.api_version]
+
+    def _stream_response_xml(self, payload, timeout, headers=None):
+        # Takes an XML tree and returns SOAP payload as an XML tree
+        if not isinstance(payload, ElementType):
+            raise ValueError("'payload' %r must be an ElementType" % payload)
+
+        account, hint = self._get_account_and_version_hint()
+        api_versions = self._get_versions_to_try(hint)
+
+        got_envelopes = False
+        for api_version in api_versions:
+            session = self.protocol.get_session()
+            try:
+                soap_payload = wrap(content=payload, version=api_version, account=account)
+                r, session = post_ratelimited(
+                    protocol=self.protocol,
+                    session=session,
+                    url=self.protocol.service_endpoint,
+                    headers=headers,
+                    data=soap_payload,
+                    allow_redirects=False,
+                    stream=True,
+                    timeout=timeout)
+                got_envelopes = False
+                for envelope in self._parse_envelopes(r):
+                    result = self._handle_xml_response(r, envelope, account, api_version, hint)
+                    if result is None:
+                        break
+                    got_envelopes = True
+                    yield result
+            finally:
+                self.protocol.release_session(session)
+
+            if got_envelopes:
+                break
+
+        if not got_envelopes:
+            raise ErrorInvalidSchemaVersionForMailboxVersion(
+                'Tried versions %s but all were invalid for account %s' % (api_versions, account))
+
+    def _parse_envelopes(self, response):
+        try:
+            envelope_str = '</Envelope>'
+            curr_envelope = ''
+            for chunk in response.iter_content():
+                if not chunk:
+                    continue
+                curr_envelope += chunk
+                index = curr_envelope.find(envelope_str)
+                if index == -1:
+                    continue
+                yield curr_envelope[0:index + len(envelope_str)]
+                curr_envelope = curr_envelope[index + len(envelope_str):]
+        except Exception as e:
+            print('Error parsing envelopes: {}'.format(e))
+            raise
+
+    def _get_response_xml(self, payload, headers=None):
+        # Takes an XML tree and returns SOAP payload as an XML tree
+        if not isinstance(payload, ElementType):
+            raise ValueError("'payload' %r must be an ElementType" % payload)
+
+        account, hint = self._get_account_and_version_hint()
+        api_versions = self._get_versions_to_try(hint)
+
         for api_version in api_versions:
             log.debug('Trying API version %s for account %s', api_version, account)
             session = self.protocol.get_session()
@@ -161,7 +272,8 @@ class EWSService(object):
                 url=self.protocol.service_endpoint,
                 headers=http_headers,
                 data=soap_payload,
-                allow_redirects=False)
+                allow_redirects=False,
+                stream=False)
             self.protocol.release_session(session)
             try:
                 soap_response_payload = to_xml(r.text)
@@ -194,6 +306,29 @@ class EWSService(object):
             raise ErrorInvalidSchemaVersionForMailboxVersion('Tried versions %s but all were invalid for account %s' %
                                                              (api_versions, account))
         raise ErrorInvalidServerVersion('Tried versions %s but all were invalid' % api_versions)
+
+    def _handle_xml_response(self, response, text, account, api_version, hint):
+        log.debug('Trying API version %s for account %s', api_version, account)
+        try:
+            soap_response_payload = to_xml(text)
+        except ParseError as e:
+            raise SOAPError('Bad SOAP response: %s' % e)
+        try:
+            res = self._get_soap_payload(soap_response=soap_response_payload)
+        except (ErrorInvalidSchemaVersionForMailboxVersion, ErrorInvalidServerVersion):
+            if not account:
+                # This should never happen for non-account services
+                raise ValueError("'account' should not be None")
+            # The guessed server version is wrong for this account. Try the next version
+            log.debug('API version %s was invalid for account %s', api_version, account)
+            return None
+        except ResponseMessageError:
+            # We got an error message from Exchange, but we still want to get any new version info from the response
+            self._update_api_version(hint=hint, api_version=api_version, response=response)
+            raise
+        else:
+            self._update_api_version(hint=hint, api_version=api_version, response=response)
+        return res
 
     def _update_api_version(self, hint, api_version, response):
         if api_version == hint.api_version and hint.build is not None:
@@ -354,6 +489,13 @@ class EWSFolderService(EWSAccountService):
         if not self.folders:
             raise ValueError('"folders" must not be empty')
         super(EWSFolderService, self).__init__(*args, **kwargs)
+
+
+class EWSSubscriptionService(EWSAccountService):
+
+    def __init__(self, account, subscription_ids):
+        self.subscription_ids = subscription_ids
+        super(EWSSubscriptionService, self).__init__(account=account)
 
 
 class PagingEWSMixIn(EWSService):
@@ -1280,7 +1422,10 @@ class SyncFolderItems(EWSFolderService):
             if c is None:
                 raise ValueError('Unknown Change tag: {}'.format(change.tag))
             yield c
-        yield self.sync_state.text
+        if self.sync_state is None:
+            yield None
+        else:
+            yield self.sync_state.text
 
     def get_payload(self, folder, shape, sync_state=None, ignore=None, max_changes=100):
         if ignore is None:
@@ -1312,10 +1457,145 @@ class SyncFolderItems(EWSFolderService):
     def _get_elements_in_response(self, response):
         result = super(SyncFolderItems, self)._get_elements_in_response(response)
         for msg in response:
-            sync_state = self._get_element_container(message=msg, name='{%s}SyncState' % MNS)
-            if sync_state is not None:
-                self.sync_state = sync_state
+            self.sync_state = self._get_element_container(message=msg, name='{%s}SyncState' % MNS)
         return result
+
+
+class Subscribe(EWSFolderService):
+    """
+    https://msdn.microsoft.com/en-us/library/office/aa566188(v=exchg.150).aspx
+
+    Currently we only support doing Subscribe for StreamingSubscriptionRequest.
+    """
+    SERVICE_NAME = 'Subscribe'
+    element_container_name = '{%s}SubscriptionId' % MNS
+
+    def call(self, event_types):
+        # Read about server affinity here: https://msdn.microsoft.com/en-us/library/office/dn458789(v=exchg.150).aspx
+        for subscription_id in self._get_elements(self.get_payload(self.folders, event_types), headers={
+            'X-AnchorMailbox': self.account.primary_smtp_address,
+            'X-PreferServerAffinity': 'True',
+        }):
+            return subscription_id
+        raise ValueError('No valid response')
+
+    def get_payload(self, folders, event_types):
+        from .events import CONCRETE_EVENT_CLASSES
+
+        subscription = create_element('m:Subscribe')
+        streaming_request = create_element('m:StreamingSubscriptionRequest')
+        subscription.append(streaming_request)
+
+        folder_ids = create_element('t:FolderIds')
+        for folder in folders:
+            folder_elem = folder.to_xml(version=self.account.version)
+            folder_ids.append(folder_elem)
+        streaming_request.append(folder_ids)
+
+        event_types_elem = create_element('t:EventTypes')
+        deduped_event_types = set()
+        # If the client only specifies either Folder*Event or Item*Event
+        # we currently don't filter them out during GetStreamingEvents
+        # because they map to the same element tag name.
+        for event_type in event_types:
+            assert event_type in CONCRETE_EVENT_CLASSES
+            deduped_event_types.add(event_type.ELEMENT_NAME)
+
+        for event_type_name in deduped_event_types:
+            if event_type_name == 'StatusEvent':
+                continue
+            event_type_elem = create_element('t:EventType')
+            event_type_elem.text = event_type_name
+            event_types_elem.append(event_type_elem)
+        streaming_request.append(event_types_elem)
+        return subscription
+
+    def _get_elements_in_container(self, container):
+        return [container.text]
+
+
+class GetStreamingEvents(EWSSubscriptionService):
+    """
+    https://msdn.microsoft.com/en-us/library/office/ff406172(v=exchg.150).aspx
+    """
+    SERVICE_NAME = 'GetStreamingEvents'
+    element_container_name = None
+
+    def call(self, timeout_minutes):
+        assert len(self.subscription_ids) == 1
+        headers = {
+            'X-PreferServerAffinity': 'True',
+            'X-AnchorMailbox': self.account.primary_smtp_address,
+        }
+        return self._stream_elements(self.get_payload(self.subscription_ids[0], timeout_minutes),
+                                     timeout=timeout_minutes * 60,
+                                     headers=headers)
+
+    def get_payload(self, subscription_id, timeout_minutes):
+        get_streaming_events = create_element('{%s}GetStreamingEvents' % MNS)
+        subscription_ids_elem = create_element('{%s}SubscriptionIds' % MNS)
+        subscription_id_elem = create_element('{%s}SubscriptionId' % TNS)
+        subscription_id_elem.text = subscription_id
+        subscription_ids_elem.append(subscription_id_elem)
+        get_streaming_events.append(subscription_ids_elem)
+
+        timeout_elem = create_element('{%s}ConnectionTimeout' % MNS)
+        timeout_elem.text = str(timeout_minutes)
+        get_streaming_events.append(timeout_elem)
+        return get_streaming_events
+
+    def _get_elements_in_response(self, response):
+        from exchangelib.notifications import Notification, ConnectionStatus
+
+        if len(response) != 1:
+            raise ValueError("Expected 'response' length 1, got %s" % response)
+        response = response[0]
+        if not isinstance(response, ElementType):
+            raise ValueError("'response' %r must be an ElementType" % response)
+
+        container_or_exc = None
+        elem_cls = None
+        for cls, name in [(Notification, '{%s}Notifications' % MNS), (ConnectionStatus, '{%s}ConnectionStatus' % MNS)]:
+            try:
+                container_or_exc = self._get_element_container(message=response, name=name)
+                elem_cls = cls
+            except TransportError as e:
+                continue
+            if isinstance(container_or_exc, Exception):
+                # pylint: disable=raising-bad-type
+                raise container_or_exc
+
+        if container_or_exc is None:
+            raise TransportError('Unable to find elements in response')
+
+        for elem in self._get_elements_in_container(container_or_exc):
+            yield elem_cls.from_xml(elem, account=self.account)
+
+    def _get_elements_in_container(self, container):
+        from exchangelib.notifications import ConnectionStatus
+        if container.tag == ConnectionStatus.response_tag():
+            return [container]
+        return [elem for elem in container]
+
+
+class Unsubscribe(EWSSubscriptionService):
+    """
+    https://msdn.microsoft.com/en-us/library/office/aa564263(v=exchg.150).aspx
+    """
+    SERVICE_NAME = 'Unsubscribe'
+    element_container_name = None
+
+    def call(self):
+        assert len(self.subscription_ids) == 1
+        for _ in self._get_elements(self.get_payload(self.subscription_ids[0])):
+            pass
+
+    def get_payload(self, subscription_id):
+        unsubscribe = create_element('{%s}Unsubscribe' % MNS)
+        subscription_id_elem = create_element('{%s}SubscriptionId' % MNS)
+        subscription_id_elem.text = subscription_id
+        unsubscribe.append(subscription_id_elem)
+        return unsubscribe
 
 
 class DeleteFolder(EWSAccountService):

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -1216,6 +1216,50 @@ class UpdateFolder(EWSAccountService):
         return updatefolder
 
 
+class SyncFolderHierarchy(EWSAccountService):
+    """
+    https://msdn.microsoft.com/en-us/library/office/aa564829(v=exchg.150).aspx
+    """
+    SERVICE_NAME = 'SyncFolderHierarchy'
+    element_container_name = '{%s}Changes' % MNS
+
+    def call(self, shape, sync_state=None):
+        from .changes import CreateFolderChange, UpdateFolderChange, DeleteFolderChange
+
+        folder_change_classes_by_tag = {
+            CreateFolderChange.response_tag: CreateFolderChange,
+            UpdateFolderChange.response_tag: UpdateFolderChange,
+            DeleteFolderChange.response_tag: DeleteFolderChange
+        }
+
+        for change in self._get_elements(payload=self.get_payload(shape, sync_state)):
+            cls = folder_change_classes_by_tag.get(change.tag)
+            if not cls:
+                raise ValueError('Unknown Change tag: {}'.format(change.tag))
+            yield cls.from_xml(change, self.account)
+        if self.sync_state is None:
+            yield None
+        else:
+            yield self.sync_state.text
+
+    def get_payload(self, shape, sync_state=None):
+        sync_folder_hierarchy = create_element('m:%s' % self.SERVICE_NAME)
+        foldershape = create_element('m:FolderShape')
+        add_xml_child(foldershape, 't:BaseShape', shape)
+        sync_folder_hierarchy.append(foldershape)
+        if sync_state is not None:
+            syncstate = create_element('m:SyncState')
+            syncstate.text = sync_state
+            sync_folder_hierarchy.append(syncstate)
+        return sync_folder_hierarchy
+
+    def _get_elements_in_response(self, response):
+        result = super(SyncFolderHierarchy, self)._get_elements_in_response(response)
+        for elem in response:
+            self.sync_state = self._get_element_container(elem, name='{%s}SyncState' % MNS)
+        return result
+
+
 class DeleteFolder(EWSAccountService):
     """
     MSDN: https://msdn.microsoft.com/en-us/library/office/aa564767(v=exchg.150).aspx

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -511,6 +511,26 @@ class EWSService(object):
     def _get_elements_in_container(container):
         return [elem for elem in container]
 
+    def add_additional_properties_to_shape(self, shape_element, additional_fields):
+        if not additional_fields:
+            return
+
+        from .fields import FieldPath
+
+        additional_field_paths = []
+
+        for field in additional_fields:
+            if isinstance(field, FieldPath):
+                field_path = field
+            else:
+                field_path = FieldPath(field=field)
+            additional_field_paths.append(field_path)
+
+        additional_properties = create_element('t:AdditionalProperties')
+        expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_field_paths))
+        set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path), self.account.version)
+        shape_element.append(additional_properties)
+
 
 class EWSAccountService(EWSService):
 
@@ -816,12 +836,7 @@ class GetItem(EWSAccountService, EWSPooledMixIn):
         getitem = create_element('m:%s' % self.SERVICE_NAME)
         itemshape = create_element('m:ItemShape')
         add_xml_child(itemshape, 't:BaseShape', shape)
-        if additional_fields:
-            additional_properties = create_element('t:AdditionalProperties')
-            expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_fields))
-            set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path),
-                          version=self.account.version)
-            itemshape.append(additional_properties)
+        self.add_additional_properties_to_shape(itemshape, additional_fields)
         getitem.append(itemshape)
         item_ids = create_element('m:ItemIds')
         is_empty = True
@@ -1120,12 +1135,7 @@ class FindItem(EWSFolderService, PagingEWSMixIn):
         finditem = create_element('m:%s' % self.SERVICE_NAME, Traversal=depth)
         itemshape = create_element('m:ItemShape')
         add_xml_child(itemshape, 't:BaseShape', shape)
-        if additional_fields:
-            additional_properties = create_element('t:AdditionalProperties')
-            expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_fields))
-            set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path),
-                          version=self.account.version)
-            itemshape.append(additional_properties)
+        self.add_additional_properties_to_shape(itemshape, additional_fields)
         finditem.append(itemshape)
         if calendar_view is None:
             view_type = create_element('m:IndexedPageItemView',
@@ -1182,12 +1192,7 @@ class FindFolder(EWSFolderService, PagingEWSMixIn):
         findfolder = create_element('m:%s' % self.SERVICE_NAME, Traversal=depth)
         foldershape = create_element('m:FolderShape')
         add_xml_child(foldershape, 't:BaseShape', shape)
-        if additional_fields:
-            additional_properties = create_element('t:AdditionalProperties')
-            expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_fields))
-            set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path),
-                          version=self.account.version)
-            foldershape.append(additional_properties)
+        self.add_additional_properties_to_shape(foldershape, additional_fields)
         findfolder.append(foldershape)
         if self.account.version.build >= EXCHANGE_2010:
             indexedpageviewitem = create_element('m:IndexedPageFolderView', MaxEntriesReturned=text_type(page_size),
@@ -1249,12 +1254,7 @@ class GetFolder(EWSAccountService):
         getfolder = create_element('m:%s' % self.SERVICE_NAME)
         foldershape = create_element('m:FolderShape')
         add_xml_child(foldershape, 't:BaseShape', shape)
-        if additional_fields:
-            additional_properties = create_element('t:AdditionalProperties')
-            expanded_fields = chain(*(f.expand(version=self.account.version) for f in additional_fields))
-            set_xml_value(additional_properties, sorted(expanded_fields, key=lambda f: f.path),
-                          version=self.account.version)
-            foldershape.append(additional_properties)
+        self.add_additional_properties_to_shape(foldershape, additional_fields)
         getfolder.append(foldershape)
         folder_ids = create_element('m:FolderIds')
         is_empty = True
@@ -1403,7 +1403,7 @@ class SyncFolderHierarchy(EWSAccountService):
     SERVICE_NAME = 'SyncFolderHierarchy'
     element_container_name = '{%s}Changes' % MNS
 
-    def call(self, shape, sync_state=None):
+    def call(self, shape, sync_state=None, additional_fields=None):
         from .changes import CreateFolderChange, UpdateFolderChange, DeleteFolderChange
 
         folder_change_classes_by_tag = {
@@ -1412,7 +1412,7 @@ class SyncFolderHierarchy(EWSAccountService):
             DeleteFolderChange.response_tag(): DeleteFolderChange,
         }
 
-        for change in self._get_elements(payload=self.get_payload(shape, sync_state)):
+        for change in self._get_elements(payload=self.get_payload(shape, sync_state, additional_fields)):
             cls = folder_change_classes_by_tag.get(change.tag)
             if not cls:
                 raise ValueError('Unknown Change tag: {}'.format(change.tag))
@@ -1422,10 +1422,11 @@ class SyncFolderHierarchy(EWSAccountService):
         else:
             yield self.sync_state.text
 
-    def get_payload(self, shape, sync_state=None):
+    def get_payload(self, shape, sync_state=None, additional_fields=None):
         sync_folder_hierarchy = create_element('m:%s' % self.SERVICE_NAME)
         foldershape = create_element('m:FolderShape')
         add_xml_child(foldershape, 't:BaseShape', shape)
+        self.add_additional_properties_to_shape(foldershape, additional_fields)
         sync_folder_hierarchy.append(foldershape)
         if sync_state is not None:
             syncstate = create_element('m:SyncState')

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -32,7 +32,7 @@ from .errors import EWSWarning, TransportError, SOAPError, ErrorTimeoutExpired, 
     ErrorItemSave, ErrorInvalidIdMalformed, ErrorMessageSizeExceeded, UnauthorizedError, \
     ErrorCannotDeleteTaskOccurrence, ErrorMimeContentConversionFailed, ErrorRecurrenceHasNoOccurrence, \
     ErrorNameResolutionMultipleResults, ErrorNameResolutionNoResults, ErrorNoPublicFolderReplicaAvailable, \
-    ErrorInvalidOperation, MalformedResponseError
+    ErrorInvalidOperation, ErrorSubscriptionUnsubscribed, MalformedResponseError
 from .ewsdatetime import EWSDateTime, NaiveDateTimeNotAllowed
 from .transport import wrap, extra_headers, SOAPNS, TNS, MNS, ENS
 from .util import chunkify, create_element, add_xml_child, get_xml_attr, to_xml, post_ratelimited, ElementType, \
@@ -174,6 +174,7 @@ class EWSService(object):
                 # Return a generator over the result elements.
                 for elem in self._get_elements_in_response(response=response):
                     yield elem
+
         except self.ERRORS_TO_CATCH_AND_RERAISE:
             raise
         except Exception:
@@ -1559,7 +1560,9 @@ class GetStreamingEvents(EWSSubscriptionService):
             try:
                 container_or_exc = self._get_element_container(message=response, name=name)
                 elem_cls = cls
-            except TransportError as e:
+            except ErrorSubscriptionUnsubscribed:
+                raise
+            except TransportError:
                 continue
             if isinstance(container_or_exc, Exception):
                 # pylint: disable=raising-bad-type

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -12,8 +12,10 @@ Exchange EWS references:
 """
 from __future__ import unicode_literals
 
+import os
 import abc
 import datetime
+import time
 from itertools import chain
 import logging
 import traceback
@@ -36,13 +38,13 @@ from .errors import EWSWarning, TransportError, SOAPError, ErrorTimeoutExpired, 
 from .ewsdatetime import EWSDateTime, NaiveDateTimeNotAllowed
 from .transport import wrap, extra_headers, SOAPNS, TNS, MNS, ENS
 from .util import chunkify, create_element, add_xml_child, get_xml_attr, to_xml, post_ratelimited, ElementType, \
-    xml_to_str, set_xml_value, peek, xml_text_to_value
+    xml_to_str, set_xml_value, peek, xml_text_to_value, PrettyXmlHandler
 from .version import EXCHANGE_2010, EXCHANGE_2010_SP2, EXCHANGE_2013, EXCHANGE_2013_SP1
 
 log = logging.getLogger(__name__)
 
 CHUNK_SIZE = 100  # A default chunk size for all services
-
+req_id = 0
 
 class EWSService(object):
     __metaclass__ = abc.ABCMeta
@@ -164,6 +166,17 @@ class EWSService(object):
                             account, traceback.format_exc(20))
                 raise
 
+    def _get_elements_from_xml_text(self, raw_text):
+        """
+        This is useful for testing.
+        """
+        try:
+            soap_response_payload = to_xml(raw_text)
+        except ParseError as e:
+            raise SOAPError('Bad SOAP response: %s' % e)
+        response = self._get_soap_payload(soap_response=soap_response_payload)
+        return self._get_elements_in_response(response=response)
+
     def _stream_elements(self, payload, timeout, headers=None):
         if not isinstance(payload, ElementType):
             raise ValueError("'payload' %r must be an ElementType" % payload)
@@ -203,6 +216,7 @@ class EWSService(object):
         if not isinstance(payload, ElementType):
             raise ValueError("'payload' %r must be an ElementType" % payload)
 
+        global req_id
         account, hint = self._get_account_and_version_hint()
         api_versions = self._get_versions_to_try(hint)
 
@@ -210,7 +224,10 @@ class EWSService(object):
         for api_version in api_versions:
             session = self.protocol.get_session()
             try:
+                req_id += 1
+                local_req_id = req_id
                 soap_payload = wrap(content=payload, version=api_version, account=account)
+                self._save_xml('request', local_req_id, soap_payload)
                 r, session = post_ratelimited(
                     protocol=self.protocol,
                     session=session,
@@ -225,6 +242,8 @@ class EWSService(object):
                     result = self._handle_xml_response(r, envelope, account, api_version, hint)
                     if result is None:
                         break
+                    for r in result:
+                        self._save_xml('response', local_req_id, r.text)
                     got_envelopes = True
                     yield result
             finally:
@@ -236,6 +255,18 @@ class EWSService(object):
         if not got_envelopes:
             raise ErrorInvalidSchemaVersionForMailboxVersion(
                 'Tried versions %s but all were invalid for account %s' % (api_versions, account))
+
+    def _save_xml(self, ftype, req_id, xml_str):
+        if os.environ.get('SAVE_RAW_XML_PATH') is None:
+            return
+        fname = os.environ.get('SAVE_RAW_XML_PATH')
+        with file(fname, 'a') as f:
+            now = time.time()
+            if ftype == 'request':
+                f.write(u'REQUEST {} >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> {}\n'.format(req_id, now))
+            elif ftype == 'response':
+                f.write(u'RESPONSE {} <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< {}\n'.format(req_id, now))
+            f.write(PrettyXmlHandler.prettify_xml(xml_str) + '\n')
 
     def _parse_envelopes(self, response):
         try:
@@ -262,11 +293,16 @@ class EWSService(object):
         account, hint = self._get_account_and_version_hint()
         api_versions = self._get_versions_to_try(hint)
 
+        global req_id
+
         for api_version in api_versions:
             log.debug('Trying API version %s for account %s', api_version, account)
             session = self.protocol.get_session()
             soap_payload = wrap(content=payload, version=api_version, account=account)
             http_headers = extra_headers(account=account)
+            req_id += 1
+            local_req_id = req_id
+            self._save_xml('request', local_req_id, soap_payload)
             r, session = post_ratelimited(
                 protocol=self.protocol,
                 session=session,
@@ -276,6 +312,7 @@ class EWSService(object):
                 allow_redirects=False,
                 stream=False)
             self.protocol.release_session(session)
+            self._save_xml('response', local_req_id, r.text)
             try:
                 soap_response_payload = to_xml(r.text)
             except ParseError as e:
@@ -1403,6 +1440,16 @@ class SyncFolderHierarchy(EWSAccountService):
         return result
 
 
+class SyncStateFinish(object):
+    def __init__(self, sync_state=None, includes_last_item_in_range=None):
+        self.sync_state = sync_state
+        self.includes_last_item_in_range = includes_last_item_in_range
+        if isinstance(sync_state, ElementType):
+            self.sync_state = sync_state.text
+        if isinstance(includes_last_item_in_range, ElementType):
+            self.includes_last_item_in_range = includes_last_item_in_range.text == 'true'
+
+
 class SyncFolderItems(EWSFolderService):
     """
     https://msdn.microsoft.com/en-us/library/office/aa563967(v=exchg.150).aspx
@@ -1426,7 +1473,7 @@ class SyncFolderItems(EWSFolderService):
         if self.sync_state is None:
             yield None
         else:
-            yield self.sync_state.text
+            yield SyncStateFinish(sync_state=self.sync_state, includes_last_item_in_range=self.includes_last_item_in_range)
 
     def get_payload(self, folder, shape, sync_state=None, ignore=None, max_changes=100):
         if ignore is None:
@@ -1459,6 +1506,7 @@ class SyncFolderItems(EWSFolderService):
         result = super(SyncFolderItems, self)._get_elements_in_response(response)
         for msg in response:
             self.sync_state = self._get_element_container(message=msg, name='{%s}SyncState' % MNS)
+            self.includes_last_item_in_range = self._get_element_container(message=msg, name='{%s}IncludesLastItemInRange' % MNS)
         return result
 
 

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -1369,9 +1369,9 @@ class SyncFolderHierarchy(EWSAccountService):
         from .changes import CreateFolderChange, UpdateFolderChange, DeleteFolderChange
 
         folder_change_classes_by_tag = {
-            CreateFolderChange.response_tag: CreateFolderChange,
-            UpdateFolderChange.response_tag: UpdateFolderChange,
-            DeleteFolderChange.response_tag: DeleteFolderChange
+            CreateFolderChange.response_tag(): CreateFolderChange,
+            UpdateFolderChange.response_tag(): UpdateFolderChange,
+            DeleteFolderChange.response_tag(): DeleteFolderChange,
         }
 
         for change in self._get_elements(payload=self.get_payload(shape, sync_state)):

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -427,7 +427,7 @@ except ImportError:
     pass
 
 
-def post_ratelimited(protocol, session, url, headers, data, allow_redirects=False):
+def post_ratelimited(protocol, session, url, headers, data, allow_redirects=False, stream=False, timeout=None):
     """
     There are two error-handling policies implemented here: a fail-fast policy intended for stand-alone scripts which
     fails on all responses except HTTP 200. The other policy is intended for long-running tasks that need to respect
@@ -493,7 +493,12 @@ Response data: %(xml_response)s
             # Always create a dummy response for logging purposes, in case we fail in the following
             r = DummyResponse(url=url, headers={}, request_headers=headers)
             try:
-                r = session.post(url=url, headers=headers, data=data, allow_redirects=False, timeout=protocol.TIMEOUT)
+                r = session.post(url=url,
+                                 headers=headers,
+                                 data=data,
+                                 allow_redirects=False,
+                                 timeout=(timeout or protocol.TIMEOUT),
+                                 stream=stream)
             except CONNECTION_ERRORS as e:
                 log.debug('Session %s thread %s: connection error POST\'ing to %s', session.session_id, thread_id, url)
                 r = DummyResponse(url=url, headers={'TimeoutException': e}, request_headers=headers)
@@ -503,7 +508,7 @@ Response data: %(xml_response)s
                 log_vals = dict(
                     retry=retry,
                     wait=wait,
-                    timeout=protocol.TIMEOUT,
+                    timeout=(timeout or protocol.TIMEOUT),
                     session_id=session.session_id,
                     thread_id=thread_id,
                     auth=session.auth,
@@ -513,7 +518,7 @@ Response data: %(xml_response)s
                     response_time=time_func() - d_start,
                     status_code=r.status_code,
                     request_headers=r.request.headers,
-                    response_headers=r.headers,
+                    response_headers=None if stream else r.headers,
                     xml_request=data,
                     xml_response=r.content,
                 )

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -289,6 +289,8 @@ class PrettyXmlHandler(logging.StreamHandler):
 
     def prettify_xml(self, xml_bytes):
         # Re-formats an XML document to a consistent style
+        if isinstance(xml_bytes, unicode):
+            xml_bytes = xml_bytes.encode('utf-8')
         return tostring(
             self.parse_bytes(xml_bytes),
             xml_declaration=True,

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -542,8 +542,12 @@ Response data: %(xml_response)s
         protocol.retire_session(session)
         raise
     except Exception as e:
-        # Let higher layers handle this. Add full context for better debugging.
-        log.error(str('%s: %s\n%s'), e.__class__.__name__, str(e), log_msg % log_vals)
+        try:
+            # Let higher layers handle this. Add full context for better debugging.
+            log.error(str('%s: %s\n%s'), e.__class__.__name__, str(e), log_msg % log_vals)
+        except UnboundLocalError:
+            # In some cases, an Exception is raised before log_vals is assigned
+            log.error(str('%s: %s'), e.__class__.__name__, str(e))
         protocol.retire_session(session)
         raise
     if r.status_code == 500 and r.text and is_xml(r.text):

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     keywords='Exchange EWS autodiscover',
     install_requires=['requests>=2.7', 'requests_ntlm>=0.2.0', 'dnspython>=1.14.0', 'pytz', 'lxml>3.0',
                       'cached_property', 'future', 'six', 'tzlocal', 'python-dateutil', 'pygments', 'defusedxml',
-                      'isodate', 'requests_kerberos'],
+                      'isodate', 'requests_kerberos', 'typing'],
     packages=['exchangelib'],
     tests_require=['PyYAML', 'requests_mock', 'psutil'],
     test_suite='tests',

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -35,6 +35,7 @@ from exchangelib.account import Account, SAVE_ONLY, SEND_ONLY, SEND_AND_SAVE_COP
 from exchangelib.attachments import FileAttachment, ItemAttachment
 from exchangelib.autodiscover import AutodiscoverProtocol, discover
 import exchangelib.autodiscover
+from exchangelib.changes import Change
 from exchangelib.configuration import Configuration
 from exchangelib.credentials import DELEGATE, IMPERSONATION, Credentials, ServiceAccount
 from exchangelib.errors import RelativeRedirect, ErrorItemNotFound, ErrorInvalidOperation, AutoDiscoverRedirect, \
@@ -2208,6 +2209,17 @@ class AccountTest(EWSTest):
             self.assertEqual(folder.name.lower(), MockCalendar.localized_names(self.account.locale)[0])
         finally:
             Calendar.get_distinguished = _orig
+
+    def test_sync_folder_hierarchy(self):
+        for change in self.account.sync_folder_hierarchy(shape='AllProperties'):
+            if isinstance(change, Change):
+                assert change.folder is not None
+            else:
+                sync_state = change
+        assert sync_state is not None
+
+        for change in self.account.sync_folder_hierarchy(shape='AllProperties', sync_state=sync_state):
+            assert not isinstance(change, Change)
 
 
 class AutodiscoverTest(EWSTest):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -44,8 +44,7 @@ from exchangelib.errors import RelativeRedirect, ErrorItemNotFound, ErrorInvalid
     ErrorFolderNotFound, ErrorInvalidRequest, SOAPError, ErrorInvalidServerVersion, NaiveDateTimeNotAllowed, \
     AmbiguousTimeError, NonExistentTimeError, ErrorUnsupportedPathForQuery, ErrorInvalidPropertyForOperation, \
     ErrorInvalidValueForProperty, ErrorPropertyUpdate, ErrorDeleteDistinguishedFolder, \
-    ErrorNoPublicFolderReplicaAvailable, ErrorServerBusy, ErrorInvalidPropertySet
-    ErrorNoPublicFolderReplicaAvailable
+    ErrorNoPublicFolderReplicaAvailable, ErrorSubscriptionNotFound, ErrorServerBusy, ErrorInvalidPropertySet
 from exchangelib.events import CONCRETE_EVENT_TYPES
 from exchangelib.ewsdatetime import EWSDateTime, EWSDate, EWSTimeZone, UTC, UTC_NOW
 from exchangelib.extended_properties import ExtendedProperty, ExternId
@@ -2947,6 +2946,23 @@ class FolderTest(EWSTest):
                     print(event)
         finally:
             self.account.unsubscribe_from_notifications(subscription_id)
+
+    def test_canceling_streaming_subscription(self):
+        subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_CLASSES)
+        unsubscribed_successfully = False
+        caught_exception = False
+        try:
+            for event in self.account.inbox.listen_for_notifications(subscription_id, timeout_s=60):
+                if isinstance(event, ConnectionStatus):
+                    self.account.inbox.unsubscribe_from_notifications(subscription_id)
+                    unsubscribed_successfully = True
+        except ErrorSubscriptionNotFound:
+            caught_exception = True
+        finally:
+            if not unsubscribed_successfully:
+                self.account.inbox.unsubscribe_from_notifications(subscription_id)
+        assert unsubscribed_successfully
+        assert caught_exception
 
 
 class BaseItemTest(EWSTest):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2222,6 +2222,17 @@ class AccountTest(EWSTest):
         for change in self.account.sync_folder_hierarchy(shape='AllProperties', sync_state=sync_state):
             assert not isinstance(change, Change)
 
+    def test_sync_folder_hierarchy_with_additional_fields(self):
+        parent_folder_id_field = Folder.get_field_by_fieldname('parent_folder_id')
+        for change in self.account.sync_folder_hierarchy(shape='IdOnly', additional_fields=[parent_folder_id_field]):
+            if isinstance(change, FolderChange):
+                assert change.folder is not None
+                assert change.folder.id is not None
+                assert change.folder.parent_folder_id is not None
+                # Check that an attribute that would normally be returned with the
+                # 'Default' shape isn't returned in this scenario
+                assert change.folder.total_count is None
+
 
 class AutodiscoverTest(EWSTest):
     def test_magic(self):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2911,15 +2911,16 @@ class FolderTest(EWSTest):
         for change in self.account.inbox.sync_folder_items(shape='Default'):
             if isinstance(change, ItemChange):
                 assert change.item is not None
-                changes_seen.add((change.item.item_id, change.item.changekey))
+                changes_seen.add((change.item.id, change.item.changekey))
             else:
-                sync_state = change
-        assert sync_state is not None
+                sync_state_finish = change
+        assert sync_state_finish is not None
+        sync_state = sync_state_finish.sync_state
 
         for change in self.account.inbox.sync_folder_items(shape='Default', sync_state=sync_state):
             if isinstance(change, ItemChange):
                 assert change.item is not None
-                assert (change.item.item_id, change.item.changekey) not in changes_seen
+                assert (change.item.id, change.item.changekey) not in changes_seen
 
     def test_streaming_subscription(self):
         subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_TYPES)
@@ -5575,15 +5576,16 @@ class CalendarTest(BaseItemTest):
         for change in self.test_folder.sync_folder_items(shape='Default'):
             if isinstance(change, ItemChange):
                 assert change.item is not None
-                changes_seen.add((change.item.item_id, change.item.changekey))
+                changes_seen.add((change.item.id, change.item.changekey))
             else:
-                sync_state = change
-        assert sync_state is not None
+                sync_state_finish = change
+        assert sync_state_finish is not None
+        sync_state = sync_state_finish.sync_state
 
         for change in self.test_folder.sync_folder_items(shape='Default', sync_state=sync_state):
             if isinstance(change, ItemChange):
                 assert change.item is not None
-                assert (change.item.item_id, change.item.changekey) not in changes_seen
+                assert (change.item.id, change.item.changekey) not in changes_seen
 
 
 class MessagesTest(BaseItemTest):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2933,6 +2933,21 @@ class FolderTest(EWSTest):
         finally:
             self.account.inbox.unsubscribe_from_notifications(subscription_id)
 
+    def test_multifolder_streaming_subscription(self):
+        folders = []
+        for folder in self.account.root.walk():
+            folders.append(folder)
+
+        subscription_id = self.account.subscribe_for_notifications(folders, CONCRETE_EVENT_CLASSES)
+        try:
+            for event in self.account.listen_for_notifications(subscription_id, timeout_s=60):
+                if isinstance(event, ConnectionStatus):
+                    print('ConnectionStatus: {}'.format(event.status))
+                else:
+                    print(event)
+        finally:
+            self.account.unsubscribe_from_notifications(subscription_id)
+
 
 class BaseItemTest(EWSTest):
     TEST_FOLDER = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2922,7 +2922,7 @@ class FolderTest(EWSTest):
                 assert (change.item.item_id, change.item.changekey) not in changes_seen
 
     def test_streaming_subscription(self):
-        subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_CLASSES)
+        subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_TYPES)
         try:
             for event in self.account.inbox.listen_for_notifications(subscription_id, timeout_s=60):
                 if isinstance(event, ConnectionStatus):
@@ -2937,7 +2937,7 @@ class FolderTest(EWSTest):
         for folder in self.account.root.walk():
             folders.append(folder)
 
-        subscription_id = self.account.subscribe_for_notifications(folders, CONCRETE_EVENT_CLASSES)
+        subscription_id = self.account.subscribe_for_notifications(folders, CONCRETE_EVENT_TYPES)
         try:
             for event in self.account.listen_for_notifications(subscription_id, timeout_s=60):
                 if isinstance(event, ConnectionStatus):
@@ -2948,7 +2948,7 @@ class FolderTest(EWSTest):
             self.account.unsubscribe_from_notifications(subscription_id)
 
     def test_canceling_streaming_subscription(self):
-        subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_CLASSES)
+        subscription_id = self.account.inbox.subscribe_for_notifications(CONCRETE_EVENT_TYPES)
         unsubscribed_successfully = False
         caught_exception = False
         try:


### PR DESCRIPTION
This is a minor issue, but I think it's stifling other error messages that we might be interested in. I had initially found this [issue](https://github.com/ecederstrand/exchangelib/issues/407) on exchangelib and thought it was a side effect of me actually messing around on the debug box, and therefore not actually a bug in the sync, but i'm still seeing the error pop up in the [logs](https://logs.nylas.com/app/kibana#/discover?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-24h,mode:quick,to:now))&_a=(columns:!(error_name,error_message,module,event),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'sync-*',key:beat.name,negate:!f,type:phrase,value:sync-10-77-0-10-debug),query:(match:(beat.name:(query:sync-10-77-0-10-debug,type:phrase)))),('$state':(store:appState),exists:(field:error_name),meta:(alias:!n,disabled:!f,index:'sync-*',key:error_name,negate:!f,type:exists,value:exists)),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:'sync-*',key:error_name,negate:!f,type:phrase,value:UnboundLocalError),query:(match:(error_name:(query:UnboundLocalError,type:phrase))))),index:'sync-*',interval:auto,query:(match_all:()),sort:!('@timestamp',desc))) yesterday (Sunday) when neither Annie nor I was on the debug box

Do we update the version on this lib? looks like not? 