### PR TITLE
remove utf-8 encoding in BOM comparison

### DIFF
--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -245,7 +245,7 @@ _forgiving_parser = ForgivingParser()
 
 def to_xml(text):
     try:
-        if text.encode('utf-8')[:BOM_LEN] == BOM:
+        if text[:BOM_LEN] == BOM:
             return fromstring(text[BOM_LEN:])
         else:
             return fromstring(text)


### PR DESCRIPTION
I had initially added this to deal with the warning `UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal` -- note, that warning does not raise as an Exception, it just shows up in the logs.

But it turns out when trying to `encode('utf-8')` that `BOM` constant we get `UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 0: ordinal not in range(128)` sooooo I'm deleting it and I think it's fair to assume the warning above is a valid sign of inequality in this particular case.

After merging this to master i'm going to rebase the `v1.11.4-0.1.2` branch on master.