### PR TITLE
Fix unicode decode error caused by unicode_literals import

### DIFF
--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -264,7 +264,7 @@ class EWSService(object):
                 f.write(u'REQUEST {} >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> {}\n'.format(req_id, now))
             elif ftype == 'response':
                 f.write(u'RESPONSE {} <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< {}\n'.format(req_id, now))
-            f.write(PrettyXmlHandler.prettify_xml(xml_str) + '\n')
+            f.write(PrettyXmlHandler.prettify_xml(xml_str) + b'\n')
 
     def _parse_envelopes(self, response):
         try:


### PR DESCRIPTION
This error cropped up when I was using the SAVE_RAW_XML_PATH environment variable to see the xml sent from exchange. `from __future__ import unicode_literals` means strings are treated like unicode strings. So we were combining the pretty xml string with a new line '\n' BUT that newline was a unicode string because of unicode literals so then it was throwing an error because the pretty xml string didn't know what encoding to use. Making the new line a byte string solves this!