### PR TITLE
Fix converting datetime to string when year is below 1900

### DIFF
--- a/exchangelib/ewsdatetime.py
+++ b/exchangelib/ewsdatetime.py
@@ -97,7 +97,12 @@ class EWSDateTime(datetime.datetime):
         if not self.tzinfo:
             raise ValueError('EWSDateTime must be timezone-aware')
         if self.tzinfo.zone == 'UTC':
-            return self.strftime('%Y-%m-%dT%H:%M:%SZ')
+            try:
+                return self.strftime('%Y-%m-%dT%H:%M:%SZ')
+            except ValueError:
+                # strftime doesn't work for dates with a year less than 1900. For reasons unknown, Exchange
+                # sometimes sends datetimes with a year < 1900. In this case, we manually return the string.
+                return '{}-{}-{}T{}:{}:{}Z'.format(self.year, self.month, self.day, self.hour, self.minute, self.second)
         return self.replace(microsecond=0).isoformat()
 
     @classmethod


### PR DESCRIPTION
Microsoft was sending some Attendees with LastResponseTime with a year of 1. The xml that is sent is below:
`<t:LastResponseTime>0001-01-02T00:00:00Z</t:LastResponseTime>`

strftime doesnt support conversion to strings for datetimes with a year < 1900. This PR fixes that by manually turning the datetime into a string if a ValueError is raised which is the type that gets raised with a year < 1900