### PR TITLE
change display_to and display_cc to TextField

### DIFF
--- a/exchangelib/items.py
+++ b/exchangelib/items.py
@@ -169,8 +169,8 @@ class Item(RegisterMixIn):
         BooleanField('reminder_is_set', field_uri='item:ReminderIsSet', is_required=True, default=False),
         IntegerField('reminder_minutes_before_start', field_uri='item:ReminderMinutesBeforeStart',
                      is_required_after_save=True, min=0, default=0),
-        CharField('display_cc', field_uri='item:DisplayCc', is_read_only=True),
-        CharField('display_to', field_uri='item:DisplayTo', is_read_only=True),
+        TextField('display_cc', field_uri='item:DisplayCc', is_read_only=True),
+        TextField('display_to', field_uri='item:DisplayTo', is_read_only=True),
         BooleanField('has_attachments', field_uri='item:HasAttachments', is_read_only=True),
         # ExtendedProperty fields go here
         CultureField('culture', field_uri='item:Culture', is_required_after_save=True, is_searchable=False),

--- a/exchangelib/properties.py
+++ b/exchangelib/properties.py
@@ -326,7 +326,7 @@ class Mailbox(EWSElement):
     FIELDS = [
         TextField('name', field_uri='Name'),
         EmailAddressField('email_address', field_uri='EmailAddress'),
-        ChoiceField('routing_type', field_uri='RoutingType', choices={Choice('SMTP')}, default='SMTP'),
+        ChoiceField('routing_type', field_uri='RoutingType', choices={Choice('SMTP'), Choice('EX')}, default='SMTP'),
         ChoiceField('mailbox_type', field_uri='MailboxType', choices={
             Choice('Mailbox'), Choice('PublicDL'), Choice('PrivateDL'), Choice('Contact'), Choice('PublicFolder'),
             Choice('Unknown'), Choice('OneOff'), Choice('GroupMailbox', supported_from=EXCHANGE_2013)


### PR DESCRIPTION
1. Addresses the exception we've been seeing where the `display_to` field value was too long for the `CharField`'s length restriction. `TextField` does not have a length restriction. ```File "/usr/share/python/cloud-core/local/lib/python2.7/site-packages/exchangelib/fields.py", line 648, in clean
    raise ValueError("'%s' value '%s' exceeds length %s" % (self.name, value, self.max_length))
ValueError: 'display_to' value 'Ayesha Mullings; Alwin Phillips; Andrew Pettigrew; Carl Clarke; Ceri-Anne Watson; Chaz-Jovan Ricketts; Che'-Andre Gordon; Davane Davis; David Gardner; Debra Clarke; Deron Spencer; Duran Brooks; Farah Mohammed; Hubert Graham; Jason Scott; Jovan Roper; Kadian Mullings; Kareem Scott; Kevin Ruddock; Marcia Dolphy; Marilyn Duhaney-Bamberry; Mark Johnson; Marlon Gayle; Matthew Moxam; Maurice Housen; Michael Dann; Mitzie Miller; Nadia Willie; Orlando  Whyte; Patrick Harty Jr.; Renee Dujoy; Ron-Cey Kirkland; Ryan Lincoln; Sharee Greenland; Simone Chin; Stephen Clarke; Tajay Linton; Taneisha Mitchell-Gayle; Xavier Bryson' exceeds length 255```

2. Addresses ```ValueError: Invalid choice 'EX' for field 'routing_type'. Valid choices are: SMTP``` by adding `EX` choice to `routing_type`