### PR TITLE
Add proper zero padding for the stringified datetimes

### DIFF
--- a/exchangelib/ewsdatetime.py
+++ b/exchangelib/ewsdatetime.py
@@ -102,7 +102,7 @@ class EWSDateTime(datetime.datetime):
             except ValueError:
                 # strftime doesn't work for dates with a year less than 1900. For reasons unknown, Exchange
                 # sometimes sends datetimes with a year < 1900. In this case, we manually return the string.
-                return '{}-{}-{}T{}:{}:{}Z'.format(self.year, self.month, self.day, self.hour, self.minute, self.second)
+                return '{:04d}-{:02d}-{:02d}T{:02d}:{:02d}:{:02d}Z'.format(self.year, self.month, self.day, self.hour, self.minute, self.second)
         return self.replace(microsecond=0).isoformat()
 
     @classmethod


### PR DESCRIPTION
This just helps with a test I wrote for odd years (year = 1 and year = 4000). It makes the manual string date times look more similar to the `.strftime` strings by adding the proper zero padding. I still dont want to only use the manual strings because I am not confident that strftime doesnt do other magic when converting to strings.