### PR TITLE
remove child enforcement from Mailbox

### DIFF
--- a/exchangelib/properties.py
+++ b/exchangelib/properties.py
@@ -336,12 +336,6 @@ class Mailbox(EWSElement):
 
     __slots__ = ('name', 'email_address', 'routing_type', 'mailbox_type', 'item_id')
 
-    def clean(self, version=None):
-        super(Mailbox, self).clean(version=version)
-        if not self.email_address and not self.item_id:
-            # See "Remarks" section of https://msdn.microsoft.com/en-us/library/office/aa565036(v=exchg.150).aspx
-            raise ValueError("Mailbox must have either 'email_address' or 'item_id' set")
-
     def __hash__(self):
         # Exchange may add 'mailbox_type' and 'name' on insert. We're satisfied if the item_id or email address matches.
         if self.item_id:


### PR DESCRIPTION
Addressing error: ```ValueError: Mailbox must have either 'email_address' or 'item_id' set```

I don't know what they're taking about in that comment, the remarks section of the [Mailbox docs](https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/mailbox) does not say what they think it does. In the `Child Elements` section they describe ALL children of Mailbox as optional.