### PR TITLE
Fix streaming notifications

### DIFF
--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -241,7 +241,8 @@ class EWSService(object):
                     if result is None:
                         break
                     for r in result:
-                        self._save_xml('response', local_req_id, r.text)
+                        if r.text is not None:
+                            self._save_xml('response', local_req_id, r.text)
                     got_envelopes = True
                     yield result
             finally:

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -530,7 +530,7 @@ Response data: %(xml_response)s
                     request_headers=r.request.headers,
                     response_headers=None if stream else r.headers,
                     xml_request=data,
-                    xml_response=r.content,
+                    xml_response=None if stream else r.content,
                 )
             log.debug(log_msg, log_vals)
             if _may_retry_on_error(r, protocol, wait):


### PR DESCRIPTION
We shouldn't try accessing `r.content` if we're streaming because
that'll hang. We also don't want to pass `None` into `_save_xml()`, so
this diff adds a check for that as well.