### PR TITLE
Modify ValueError exception from folders.py to include more useful info

### DIFF
--- a/exchangelib/folders.py
+++ b/exchangelib/folders.py
@@ -531,7 +531,7 @@ class Folder(RegisterMixIn, SearchableMixIn):
         try:
             return cls.ITEM_MODEL_MAP[tag]
         except KeyError:
-            raise ValueError('Item type %s was unexpected in a %s folder' % (cls.__name__, cls.__name__))
+            raise ValueError('Item type %s was unexpected in a %s folder' % (tag, cls.__name__))
 
     def allowed_fields(self):
         # Return non-ID fields of all item classes allowed in this folder type


### PR DESCRIPTION
We saw this error last week when we had accounts syncing. 
```
raise ValueError('Item type %s was unexpected in a %s folder' % (cls.__name__, cls.__name__))
``` 

`ValueError: Item type Folder was unexpected in a Folder folder`

The exception was printing cls.__name__ twice which is redundant and not helpful. This fixes that by changing one of the calls to print the tag instead. 