### PR TITLE
Keep read_only fields in to_xml output

### DIFF
--- a/exchangelib/properties.py
+++ b/exchangelib/properties.py
@@ -136,8 +136,8 @@ class EWSElement(object):
 
         # Add elements and values
         for f in self.supported_fields(version=version):
-            if f.is_read_only:
-                continue
+            # Exchangelib previously skipped read_only fields but Nylas likes to keep them
+            # to surface fields like `is_cancelled` and `organizer` in event raw data
             value = getattr(self, f.name)
             if value is None or (f.is_list and not value):
                 continue


### PR DESCRIPTION
Most notably, this will preserve 'DeletedOccurrences' in event `raw_data`, which we use to create exdates.