### PR TITLE
[scripts] A simple script to publish versions easily

### DIFF
--- a/scripts/publish-new-nylas-version
+++ b/scripts/publish-new-nylas-version
@@ -44,17 +44,19 @@ def main():
 
     print('Creating git tag')
     res = os.system('git tag {}'.format(git_tag))
+    return_code = os.WEXITSTATUS(res)
 
-    if os.WEXITSTATUS(res) != 0:
+    if return_code != 0:
         print('Error creating git tag! Bailing out.')
-        sys.exit(-1)
+        sys.exit(return_code)
 
     print('Pushing tag')
     res = os.system('git push origin --tags')
+    return_code = os.WEXITSTATUS(res)
 
-    if os.WEXITSTATUS(res) != 0:
+    if return_code != 0:
         print('Error pushing git tag to origin! Bailing out.')
-        sys.exit(-1)
+        sys.exit(return_code)
 
     sys.exit(0)
 

--- a/scripts/publish-new-nylas-version
+++ b/scripts/publish-new-nylas-version
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+# a simple script to release a new version of our internal exchangelib fork.
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
+
+import os
+import sys
+import argparse
+from exchangelib import __version__ as exchangelib_version
+
+
+def ask(message):
+    # type: (str) -> bool
+    # shamelessly stolen from: https://stackoverflow.com/a/3042378
+
+    # raw_input returns the empty string for "enter"
+    yes = {'yes', 'y', 'ye', 'yay', ''}
+    no = {'no', 'n', 'nay'}
+
+    while True:
+        sys.stdout.write(message + ' ')
+        choice = raw_input().lower()
+        if choice in yes:
+            return True
+        elif choice in no:
+            return False
+        else:
+            print("Please respond with 'yes' or 'no'")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('nylas_internal_version', help='Internal version number of our Exchangelib fork')
+    args = parser.parse_args()
+    git_tag = 'v{}-{}'.format(exchangelib_version, args.nylas_internal_version)
+
+    create_tag = ask('Going to create and push a git tag with version `{}` (y/n)'.format(git_tag))
+    if not create_tag:
+        print('Bailing out.')
+        sys.exit(-1)
+
+    print('Creating git tag')
+    os.system('git tag {}'.format(git_tag))
+
+    print('Pushing tag')
+    os.system('git push origin --tags')
+
+if __name__ == '__main__':
+    main()

--- a/scripts/publish-new-nylas-version
+++ b/scripts/publish-new-nylas-version
@@ -31,20 +31,31 @@ def ask(message):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('nylas_internal_version', help='Internal version number of our Exchangelib fork')
+    parser.add_argument('nylas_internal_version',
+                        help='Internal version number of our Exchangelib fork')
     args = parser.parse_args()
     git_tag = 'v{}-{}'.format(exchangelib_version, args.nylas_internal_version)
 
-    create_tag = ask('Going to create and push a git tag with version `{}` (y/n)'.format(git_tag))
+    create_tag = ask('Going to create and push a git tag '
+                     'with version `{}` (Y/n)'.format(git_tag))
     if not create_tag:
         print('Bailing out.')
         sys.exit(-1)
 
     print('Creating git tag')
-    os.system('git tag {}'.format(git_tag))
+    res = os.system('git tag {}'.format(git_tag))
+
+    if os.WEXITSTATUS(res) != 0:
+        print('Error creating git tag! Bailing out.')
+        sys.exit(-1)
 
     print('Pushing tag')
-    os.system('git push origin --tags')
+    res = os.system('git push origin --tags')
+
+    if os.WEXITSTATUS(res) != 0:
+        print('Error pushing git tag to origin! Bailing out.')
+        sys.exit(-1)
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/publish-new-nylas-version
+++ b/scripts/publish-new-nylas-version
@@ -56,6 +56,8 @@ def main():
         print('Error pushing git tag to origin! Bailing out.')
         sys.exit(-1)
 
+    sys.exit(0)
+
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Whenever I make changes to exchangelib I have to spend 5 mins
remembering how to tag them correctly (which involves googling about how
to create git tags and pushing them).

This time adds up so I decided to write a quick script to make things
quicker.

### How does it work?

You just have to call `scripts/publish-new-nylas-version $NEW_VERSION` and the script will create a git tag named `v$EXCHANGELIB_VERSION-$NEW_VERSION` and push it to GitHub.