### PR TITLE
Don't verify SSL certificates

### DIFF
--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -125,6 +125,15 @@ class BaseProtocol(object):
 
     def create_session(self):
         session = requests.sessions.Session()
+        session.verify = False
+
+        # This was copy/pasted from our (Nylas's) EAS code, but it's possible
+        # that it's no longer necessary. I'm not really sure what the current
+        # state is from the linked pull request. Copy/pasted comment:
+        # Prevents environment variables from overriding session.verify setting
+        # See https://github.com/kennethreitz/requests/pull/3506
+        s.trust_env = False
+
         # Add some extra info
         session.session_id = sum(map(ord, str(os.urandom(100))))  # Used for debugging messages in services
         session.protocol = self
@@ -139,6 +148,15 @@ class BaseProtocol(object):
     @classmethod
     def raw_session(cls):
         s = requests.sessions.Session()
+        s.verify = False
+
+        # This was copy/pasted from our (Nylas's) EAS code, but it's possible
+        # that it's no longer necessary. I'm not really sure what the current
+        # state is from the linked pull request. Copy/pasted comment:
+        # Prevents environment variables from overriding session.verify setting
+        # See https://github.com/kennethreitz/requests/pull/3506
+        s.trust_env = False
+
         s.mount('http://', adapter=cls.get_adapter())
         s.mount('https://', adapter=cls.get_adapter())
         return s

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -514,7 +514,8 @@ Response data: %(xml_response)s
                                  data=data,
                                  allow_redirects=False,
                                  timeout=(timeout or protocol.TIMEOUT),
-                                 stream=stream)
+                                 stream=stream,
+                                 verify=False)
             except CONNECTION_ERRORS as e:
                 log.debug('Session %s thread %s: connection error POST\'ing to %s', session.session_id, thread_id, url)
                 r = DummyResponse(url=url, headers={'TimeoutException': e}, request_headers=headers)


### PR DESCRIPTION
Some users have self-signed certificates that fail SSL verification, so
this diff changes the requests we make to explicitly not verify SSL
certificates.