### PR TITLE
Add a flag ExtendedProperty for MessageItems

### DIFF
--- a/exchangelib/__init__.py
+++ b/exchangelib/__init__.py
@@ -7,7 +7,7 @@ from .autodiscover import discover
 from .configuration import Configuration
 from .credentials import DELEGATE, IMPERSONATION, Credentials, ServiceAccount
 from .ewsdatetime import EWSDate, EWSDateTime, EWSTimeZone, UTC, UTC_NOW
-from .extended_properties import ExtendedProperty, ExternId
+from .extended_properties import ExtendedProperty, ExternId, Flag
 from .folders import Folder, FolderCollection, SHALLOW, DEEP
 from .items import AcceptItem, TentativelyAcceptItem, DeclineItem, CalendarItem, CancelCalendarItem, Contact, \
     DistributionList, Message, PostItem, Task
@@ -53,3 +53,7 @@ CalendarItem.register('extern_id', ExternId)
 Message.register('extern_id', ExternId)
 Contact.register('extern_id', ExternId)
 Task.register('extern_id', ExternId)
+
+############# Nylas Registered Extended Properties ###########
+Message.register('flag', Flag)
+

--- a/exchangelib/extended_properties.py
+++ b/exchangelib/extended_properties.py
@@ -268,8 +268,8 @@ class ExternId(ExtendedProperty):
 
 ############# Nylas Extended Porperties ##############
 
-When used, this flag property returns 0 for Not Flagged messages, 1 for Flagged messages and 2 for Completed messages.
-See: https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/flagstatus for a description of each status.
+# When used, this flag property returns 0 for Not Flagged messages, 1 for Flagged messages and 2 for Completed messages.
+# See: https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/flagstatus for a description of each status.
 class Flag(ExtendedProperty):
 	property_tag = 0x1090
 	property_type = 'Integer'

--- a/exchangelib/extended_properties.py
+++ b/exchangelib/extended_properties.py
@@ -264,3 +264,10 @@ class ExternId(ExtendedProperty):
     property_type = 'String'
 
     __slots__ = ExtendedProperty.__slots__
+
+
+############# Nylas Extended Porperties ##############
+class Flag(ExtendedProperty):
+	property_tag = 0x1090
+	property_type = 'Integer'
+

--- a/exchangelib/extended_properties.py
+++ b/exchangelib/extended_properties.py
@@ -267,6 +267,9 @@ class ExternId(ExtendedProperty):
 
 
 ############# Nylas Extended Porperties ##############
+
+When used, this flag property returns 0 for Not Flagged messages, 1 for Flagged messages and 2 for Completed messages.
+See: https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/flagstatus for a description of each status.
 class Flag(ExtendedProperty):
 	property_tag = 0x1090
 	property_type = 'Integer'


### PR DESCRIPTION
Flag status isn't in the default EWS MessageItem Schema so this adds the functionality to set and get a message's flag status using something like `message_item.flag`. This prints `None` for non-flagged messages, `1` for completed and `2` for follow-up.