### PR TITLE
Add OAuth support to Exchangelib

### DIFF
--- a/exchangelib/__init__.py
+++ b/exchangelib/__init__.py
@@ -5,7 +5,7 @@ from .account import Account
 from .attachments import FileAttachment, ItemAttachment
 from .autodiscover import discover
 from .configuration import Configuration
-from .credentials import DELEGATE, IMPERSONATION, Credentials, ServiceAccount
+from .credentials import DELEGATE, IMPERSONATION, Credentials, OAuthCredentials, ServiceAccount
 from .ewsdatetime import EWSDate, EWSDateTime, EWSTimeZone, UTC, UTC_NOW
 from .extended_properties import ExtendedProperty, ExternId, Flag
 from .folders import Folder, FolderCollection, SHALLOW, DEEP

--- a/exchangelib/credentials.py
+++ b/exchangelib/credentials.py
@@ -73,6 +73,27 @@ class Credentials(object):
         return self.username
 
 
+@python_2_unicode_compatible
+class OAuthCredentials(Credentials):
+    """
+    Keeps login info the way Office365 likes it.
+    :param token: Office365 access token
+
+    Note that you should either pass a password or an access token, not both.
+    """
+    def __init__(self, token):
+        self.token = token
+
+    def __eq__(self, other):
+        return self.token == other.token
+
+    def __hash__(self):
+        return hash(self.token)
+
+    def __repr__(self):
+        return self.__class__.__name__ + ' ********'
+
+
 class ServiceAccount(Credentials):
     def __init__(self, username, password, max_wait=3600):
         """

--- a/exchangelib/errors.py
+++ b/exchangelib/errors.py
@@ -60,6 +60,10 @@ class UnauthorizedError(EWSError):
     pass
 
 
+class InvalidTokenError(EWSError):
+    pass
+
+
 @python_2_unicode_compatible
 class RedirectError(TransportError):
     def __init__(self, url):

--- a/exchangelib/transport.py
+++ b/exchangelib/transport.py
@@ -9,7 +9,7 @@ import requests_kerberos
 
 from .credentials import IMPERSONATION
 from .errors import UnauthorizedError, TransportError, RedirectError, RelativeRedirect
-from .util import create_element, add_xml_child, get_redirect_url, xml_to_str, ns_translation
+from .util import create_element, add_xml_child, get_redirect_url, xml_to_str, ns_translation, HTTPOAuthAuth
 
 log = logging.getLogger(__name__)
 
@@ -19,12 +19,15 @@ NTLM = 'NTLM'
 BASIC = 'basic'
 DIGEST = 'digest'
 GSSAPI = 'gssapi'
+OAUTH = 'OAuth'
+
 
 AUTH_TYPE_MAP = {
     NTLM: requests_ntlm.HttpNtlmAuth,
     BASIC: requests.auth.HTTPBasicAuth,
     DIGEST: requests.auth.HTTPDigestAuth,
     GSSAPI: requests_kerberos.HTTPKerberosAuth,
+    OAUTH: HTTPOAuthAuth,
     NOAUTH: None,
 }
 
@@ -76,6 +79,10 @@ def get_auth_instance(credentials, auth_type):
     model = AUTH_TYPE_MAP[auth_type]
     if model is None:
         return None
+
+    if auth_type == OAUTH:
+        return model(token=credentials.token)
+
     username = credentials.username
     if auth_type == NTLM and credentials.type == credentials.EMAIL:
         username = '\\' + username

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -8,6 +8,7 @@ import logging
 import re
 import socket
 import time
+import urllib2
 
 # Import _etree via defusedxml instead of directly from lxml.etree, to silence overly strict linters
 from defusedxml.lxml import parse, fromstring, tostring, GlobalParserTLS, RestrictedElement, _etree
@@ -18,11 +19,12 @@ import isodate
 from pygments import highlight
 from pygments.lexers.html import XmlLexer
 from pygments.formatters.terminal import TerminalFormatter
+import requests.auth
 import requests.exceptions
 from six import text_type, string_types
 
 from .errors import TransportError, RateLimitError, RedirectError, RelativeRedirect, CASError, UnauthorizedError, \
-    ErrorInvalidSchemaVersionForMailboxVersion
+    InvalidTokenError, ErrorInvalidSchemaVersionForMailboxVersion
 
 time_func = time.time if PY2 else time.monotonic
 log = logging.getLogger(__name__)
@@ -612,22 +614,70 @@ def _redirect_or_fail(response, redirects, allow_redirects):
     return redirect_url, redirects
 
 
+def extract_oauth_error(www_authenticate_header):
+    # Exchange fact #234265 - when using Office365 with an expired access token,
+    # Exchange will simply raise a 401 error and return an HTML error page. However,
+    # if you dig into the `WWW-Authenticate` header, you'll see something like this:
+    # `'Bearer client_id="*", trusted_issuers="*", token_types="app_asserted_user_v1 service_asserted_app_v1",
+    # authorization_uri="https://login.windows.net/common/oauth2/authorize", error="invalid_token"`
+    # This function extracts this error field.
+    if www_authenticate_header.startswith('Bearer') is False:
+        return None
+
+    _, _, value = www_authenticate_header.partition('Bearer')
+    items = urllib2.parse_http_list(value)
+
+    # Sometime Exchange returns elements which aren't key-values,
+    # e.g: `Bearer Realm="",Negotiate,Basic Realm=""`
+    filtered_items = [item for item in items if '=' in item]
+    filtered_options = urllib2.parse_keqv_list(filtered_items)
+
+    if 'error' in filtered_options:
+        return filtered_options['error']
+
+    return None
+
+
 def _raise_response_errors(response, protocol, log_msg, log_vals):
     cas_error = response.headers.get('X-CasErrorCode')
+    www_authenticate = response.headers.get('WWW-Authenticate')
+
     if cas_error:
         if cas_error.startswith('CAS error:'):
             # Remove unnecessary text
             cas_error = cas_error.split(':', 1)[1].strip()
         raise CASError(cas_error=cas_error, response=response)
+
     if response.status_code == 500 and ('The specified server version is invalid' in response.text or
                                         'ErrorInvalidSchemaVersionForMailboxVersion' in response.text):
         raise ErrorInvalidSchemaVersionForMailboxVersion('Invalid server version')
+
     if 'The referenced account is currently locked out' in response.text:
         raise TransportError('The service account is currently locked out')
-    if response.status_code == 401 and protocol.credentials.fail_fast:
-        # This is a login failure
-        raise UnauthorizedError('Wrong username or password for %s' % response.url)
+
+    if response.status_code == 401:
+        if www_authenticate is not None:
+            error = extract_oauth_error(www_authenticate)
+            if error == 'invalid_token':
+                raise InvalidTokenError('Invalid Office365 OAuth token')
+
+        if protocol.credentials.fail_fast:
+            # This is a login failure
+            raise UnauthorizedError('Wrong username or password for %s' % response.url)
+
     if 'TimeoutException' in response.headers:
         raise response.headers['TimeoutException']
+
     # This could be anything. Let higher layers handle this. Add full context for better debugging.
     raise TransportError(str('Unknown failure\n') + log_msg % log_vals)
+
+
+class HTTPOAuthAuth(requests.auth.AuthBase):  # type: ignore
+    """Helper class for setting the Authorization header on HTTP requests."""
+
+    def __init__(self, token):
+        self.token = token
+
+    def __call__(self, r):
+        r.headers['Authorization'] = 'Bearer {}'.format(self.token)
+        return r


### PR DESCRIPTION
This PR contains all the changes to support OAuth within Exchangelib. It's pretty straightforward and is inspired by this comment from the Exchangelib issue tracker: https://github.com/ecederstrand/exchangelib/issues/90#issuecomment-489881088 

Basically, we just needed to add a new authentication type and pass the required parameters during auth. If there's an issue with the auth (e.g: the authentication token expires), we raise an `InvalidTokenError`. 

That's about it! Once this is landed, I'll make a PR to the Exchangelib repo to make sure other people benefit from this.