### PR TITLE
Implement support for OccurrenceItemId

### DIFF
--- a/exchangelib/properties.py
+++ b/exchangelib/properties.py
@@ -171,8 +171,9 @@ class EWSElement(object):
 
     @classmethod
     def supported_fields(cls, version=None):
-        # Return non-ID field names. If version is specified, only return the fields supported by this version
-        return tuple(f for f in cls.FIELDS if not f.is_attribute and f.supports_version(version))
+        # Return non-ID field names if they're not used only for syncback.
+        # If version is specified, only return the fields supported by this version
+        return tuple(f for f in cls.FIELDS if not f.is_attribute and not f.is_syncback_only and f.supports_version(version))
 
     @classmethod
     def get_field_by_fieldname(cls, fieldname):
@@ -321,6 +322,28 @@ class PersonaId(ItemId):
         return '{%s}%s' % (TNS, cls.ELEMENT_NAME)
 
     __slots__ = ItemId.__slots__
+
+
+class OccurrenceItemId(ItemId):
+    # https://docs.microsoft.com/en-us/exchange/client-developer/web-service-reference/occurrenceitemid
+    ELEMENT_NAME = 'OccurrenceItemId'
+
+    MASTER_ID_ATTR = 'RecurringMasterId'
+    CHANGEKEY_ATTR = 'ChangeKey'
+    INSTANCE_INDEX_ATTR = 'InstanceIndex'
+    FIELDS = [
+        IdField('master_id', field_uri=MASTER_ID_ATTR, is_required=True),
+        IdField('changekey', field_uri=CHANGEKEY_ATTR, is_required=False),
+        IdField('instance_index', field_uri=INSTANCE_INDEX_ATTR, is_required=True),
+    ]
+
+    __slots__ = ('master_id', 'changekey', 'instance_index')
+
+    def __init__(self, *args, **kwargs):
+        if not kwargs:
+            # Allow to set attributes without keyword
+            kwargs = dict(zip(self.__slots__, args))
+        super(OccurrenceItemId, self).__init__(**kwargs)
 
 
 class Mailbox(EWSElement):


### PR DESCRIPTION
This identifier field allows us to indicate a specific occurrence within
a recurring series so that we can make individual changes to it. You can
also update occurrences with their direct item id, but unless you're
storing every single occurrence on your end, you're not going to have
the item id for every occurrence. The OccurrenceItemId identifies an
occurrence via the master event's item id and the instance number of the
occurrence within the series.