### PR TITLE
First decode and encode utf-8 before falling back to chardet

### DIFF
--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -516,7 +516,10 @@ Response data: %(xml_response)s
             except UnicodeDecodeError:
                 import chardet
                 encoding_info = chardet.detect(data)
-                data = data.decode('utf-8').encode(encoding_info['encoding'])
+                if encoding_info['encoding'] in ['ISO-8859-1', 'Windows-1252']:
+                    data = data.decode("utf-8").encode("utf-8")
+                else:
+                    data = data.decode('utf-8').encode(encoding_info['encoding'])
             try:
                 r = session.post(url=url,
                                  headers=headers,


### PR DESCRIPTION
This pr attempts to fix cases where the exchange server throws an `ErrorSchemaValidation: The request failed schema validation` error. This error's thrown after we post the data that we had encoded based on the chardet detected encoding if it detects it to be  'ISO-8859-1' or 'Windows-1252'. If it's detected as 'utf-8' and we post with that encoding then the request succeeds. My inclination was not to use chardet at all, but it was put in place to fix https://app.clubhouse.io/nylas/story/18092/event-creation-fails-in-syncback-with-unicodedecodeerror which I can't seem to reproduce so leaving that in as a guard rail.

CH Task: https://app.clubhouse.io/nylas/story/26621/create-event-schema-validation-error