### PR TITLE
catch another unicodedecodeerror

### DIFF
--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -514,11 +514,11 @@ Response data: %(xml_response)s
             try:
                 data = data.encode('utf-8')
             except UnicodeDecodeError:
-                import chardet
-                encoding_info = chardet.detect(data)
-                if encoding_info['encoding'] in ['ISO-8859-1', 'Windows-1252']:
-                    data = data.decode("utf-8").encode("utf-8")
-                else:
+                try:
+                    data = data.decode('utf-8').encode('utf-8')
+                except UnicodeDecodeError:
+                    import chardet
+                    encoding_info = chardet.detect(data)
                     data = data.decode('utf-8').encode(encoding_info['encoding'])
             try:
                 r = session.post(url=url,


### PR DESCRIPTION
Addresses https://app.clubhouse.io/nylas/story/27965/unicodedecodeerror-in-syncback-persisting-at-low-er-rate-when-certain-unicode-characters-are-used-in-the-event-payload.

Again try to send utf-8 encoded data to the exchange server unless encoding as such results in a UnicodeDecodeError. 