### PR TITLE
Force using Exchange 2016 protocol for Exchange 2019

### DIFF
--- a/exchangelib/version.py
+++ b/exchangelib/version.py
@@ -102,6 +102,13 @@ class Build(object):
     def api_version(self):
         if EXCHANGE_2013_SP1 <= self < EXCHANGE_2016:
             return 'Exchange2013_SP1'
+
+        # Force Exchange 2016 protocol version for Exchange 2019
+        # because Exchangelib doesn't work out of the box with
+        # service accounts on these servers.
+        if self >= EXCHANGE_2019:
+            return 'Exchange2016'
+
         try:
             return self.API_VERSION_MAP[self.major_version][self.minor_version]
         except KeyError:


### PR DESCRIPTION
Testing with a stock on-prem Exchange 2019 server with a service account, the sync wouldn't work on the latest version of the protocol. However, manually setting the version to 2016 fixed the issue.

This is a workaround to this bug. I expect it to not cause downstream issues because:
1. probably existing Exchange 2019 are already broken 
2. We'd still be using Exchange 2016 which is a version of the protocol we've supported for years.

Please let me know if you have any questions!