### PR TITLE
typing is a Py35 backport; don't depend on it if you're above py35

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     keywords='Exchange EWS autodiscover',
     install_requires=['requests>=2.7', 'requests_ntlm>=0.2.0', 'dnspython>=1.14.0', 'pytz', 'lxml>3.0',
                       'cached_property', 'future', 'six', 'tzlocal', 'python-dateutil', 'pygments', 'defusedxml',
-                      'isodate', 'requests_kerberos', 'typing'],
+                      'isodate', 'requests_kerberos', "typing; python_version < '3.5'"],
     packages=['exchangelib'],
     tests_require=['PyYAML', 'requests_mock', 'psutil'],
     python_requires=">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*",


### PR DESCRIPTION
From https://pypi.org/project/typing/:
> NOTE: in Python 3.5 and later, the typing module lives in the stdlib, and installing this package has NO EFFECT, because stdlib takes higher precedence than the installation directory.

and

> For package maintainers, it is preferred to use `typing;python_version<"3.5"` if your package requires it to support earlier Python versions. This will avoid shadowing the stdlib typing module when your package is installed via pip install -t . on Python 3.5 or later.