### PR TITLE
Increase session pool size to 500

### DIFF
--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -39,7 +39,11 @@ class BaseProtocol(object):
     # The maximum number of sessions (== TCP connections, see below) we will open to this service endpoint. Keep this
     # low unless you have an agreement with the Exchange admin on the receiving end to hammer the server and
     # rate-limiting policies have been disabled for the connecting user.
-    SESSION_POOLSIZE = 4
+    # This pool is shared across all accounts that are using the same service account in a single
+    # process, so we need it to be high enough that our greenlets aren't blocking waiting for a session.
+    # Since we manage our own connections well, we don't need to worry about exchangelib throttling
+    # our connections for us.
+    SESSION_POOLSIZE = 500
     # We want only 1 TCP connection per Session object. We may have lots of different credentials hitting the server and
     # each credential needs its own session (NTLM auth will only send credentials once and then secure the connection,
     # so a connection can only handle requests for one credential). Having multiple connections ser Session could


### PR DESCRIPTION
When running a stress test for thousands of Exchange accounts authenticated with the same service account, it causes exchangelib to throttle us because there's only 4 sessions per-process that are shared across all accounts with the same credentials. 
`exchangelib` does a blocking get when waiting for a session to free up, so accounts become unresponsive waiting for an open session. When moving this up to 1024 in a testing environment, it completely eliminated any unresponsive accounts. I'm settling on 500 for now because that should be enough given the number of accounts we normally have in a process for a single service account and I don't want any unintended consequences of a higher limit negatively impacting Exchange servers or our own servers. 

From looking at the code, it uses  LIFO queue and doesn't automatically create connections to the server based on the pool size. I also checked the `lsof` of a debug process to see it didn't have 1k open connections just from increasing this value. 
