### PR TITLE
Allow variable pool size on BaseProtocol / Protocol

### DIFF
--- a/exchangelib/configuration.py
+++ b/exchangelib/configuration.py
@@ -31,7 +31,7 @@ class Configuration(object):
         account = Account(primary_smtp_address='john@example.com', credentials=credentials, autodiscover=True)
 
     """
-    def __init__(self, credentials, server=None, has_ssl=True, service_endpoint=None, auth_type=None, version=None):
+    def __init__(self, credentials, server=None, has_ssl=True, service_endpoint=None, auth_type=None, version=None, **kwargs):
         if auth_type is not None and auth_type not in AUTH_TYPE_MAP:
             raise ValueError('Unsupported auth type %s' % auth_type)
         if not (server or service_endpoint):
@@ -43,7 +43,8 @@ class Configuration(object):
             service_endpoint=service_endpoint,
             auth_type=auth_type,
             credentials=credentials,
-            version=version
+            version=version,
+            **kwargs
         )
 
     @property

--- a/exchangelib/protocol.py
+++ b/exchangelib/protocol.py
@@ -52,7 +52,7 @@ class BaseProtocol(object):
     # The adapter class to use for HTTP requests. Override this if you need e.g. proxy support or specific TLS versions
     HTTP_ADAPTER_CLS = requests.adapters.HTTPAdapter
 
-    def __init__(self, service_endpoint, credentials, auth_type, is_service_account=False):
+    def __init__(self, service_endpoint, credentials, auth_type, pool_size=None):
         if not isinstance(credentials, Credentials):
             raise ValueError("'credentials' %r must be a Credentials instance" % credentials)
         if auth_type is not None:
@@ -63,7 +63,7 @@ class BaseProtocol(object):
         self.service_endpoint = service_endpoint
         self.auth_type = auth_type
         self._session_pool = None  # Consumers need to fill the session pool themselves
-        self.is_service_account = is_service_account
+        self.pool_size = pool_size
 
     def __del__(self):
         # pylint: disable=bare-except
@@ -227,11 +227,7 @@ class Protocol(with_metaclass(CachingProtocol, BaseProtocol)):
 
         # Try to behave nicely with the Exchange server. We want to keep the connection open between requests.
         # We also want to re-use sessions, to avoid the NTLM auth handshake on every request.
-        pool_size = self.SESSION_POOLSIZE
-        if self.is_service_account:
-            # We run 110 accounts per process, so this gives us a session per-streaming connection
-            # along with some headroom for background polling and historical sync
-            pool_size = 150
+        pool_size = self.pool_size or self.SESSION_POOLSIZE
         self._session_pool = LifoQueue(maxsize=pool_size)
         for _ in range(pool_size):
             self._session_pool.put(self.create_session(), block=False)
@@ -252,9 +248,10 @@ class Protocol(with_metaclass(CachingProtocol, BaseProtocol)):
         # larger than the connection pool so we have time to process data without idling the connection.
         # Create the pool as the last thing here, since we may fail in the version or auth type guessing, which would
         # leave open threads around to be garbage collected.
-        thread_poolsize = 4 * self.SESSION_POOLSIZE
-        if self.is_service_account:
-            thread_poolsize = pool_size
+        if self.pool_size:
+            thread_poolsize = 4 * self.pool_size
+        else:
+            thread_poolsize = 4 * self.SESSION_POOLSIZE
         self.thread_pool = ThreadPool(processes=thread_poolsize)
 
     def get_timezones(self, timezones=None, return_full_timezone_data=False):


### PR DESCRIPTION
Due to the blanket increase in session pool size to 500, we were seeing memory issues. 
This is a more targeted solution that adds support for larger pool sizes only for service accounts. 

I think the memory issues were two-fold:
- exchangelib creates a bunch of `requests.session.Session` objects, each with a single TCP connection that remains open once created
- exchangelib creates a bunch of multiprocesses using the `ThreadPool`


Tested this locally in a debugger and stepped through each part to verify it has the proper behavior


