### PR TITLE
ch34283 check for invalid attachment responses

### DIFF
--- a/exchangelib/properties.py
+++ b/exchangelib/properties.py
@@ -145,6 +145,9 @@ class EWSElement(object):
             value = getattr(self, f.name)
             if value is None or (f.is_list and not value):
                 continue
+            if f.name == "ResponseCode" and value != "NoError":
+                log.error("Error in exchange response "+value)
+                continue
             set_xml_value(elem, f.to_xml(value, version=version), version)
         return elem
 


### PR DESCRIPTION
@billwjo we were talking about this fix to properties.toxml

attachments.py: ln 180 assumes a responseCode of NoError
- it feels like an invalid attachment id would be caught here, but I think we were also talking about logging errors in a more generic way, and this is indicated by the ResponseCode:NoError text element (error otherwise). There are a couple options

1. Gets file attachment- Attachments:content()
    - Ln 155 should check for error, but isn't the really ErrorCode in the parent element?
2. Fields
    - Ln 845 could check for ResponseCode if all responses follow the <ResponseCode>NoError
        - Or if not NoErrror, log InvalidAttachmentId
        - if not NoError log the error (whatever is in the text element)
3. Properties
    - Ln 145 has the name and value and could check for ResponseCode != NoError

IMPROVE:
1. the strings in the check should be in const and defined elsewhere
2. looking for the test to run before I can validate this fix

