### PR TITLE
Deprecate the _get_shortname_from_docs method

### DIFF
--- a/exchangelib/transport.py
+++ b/exchangelib/transport.py
@@ -115,15 +115,6 @@ def get_autodiscover_authtype(service_endpoint, data):
     return _get_auth_method_from_response(response=r)
 
 
-def get_docs_authtype(docs_url):
-    # Get auth type by tasting headers from the server. Don't do HEAD requests. It's too error prone.
-    log.debug('Getting docs auth type for %s', docs_url)
-    from .protocol import BaseProtocol
-    with BaseProtocol.raw_session() as s:
-        r = s.get(url=docs_url, headers=DEFAULT_HEADERS.copy(), allow_redirects=True, timeout=BaseProtocol.TIMEOUT)
-    return _get_auth_method_from_response(response=r)
-
-
 def get_service_authtype(service_endpoint, versions, name):
     # Get auth type by tasting headers from the server. Only do POST requests. HEAD is too error prone, and some servers
     # are set up to redirect to OWA on all requests except POST to /EWS/Exchange.asmx


### PR DESCRIPTION
It often causes more harm than actual benefit.

Upstream exchangelib has also removed this method.

Refs incident-20210527.