### PR TITLE
Fixed bug with title >255 characters not showing up on EWS calendar

### DIFF
--- a/exchangelib/items.py
+++ b/exchangelib/items.py
@@ -142,7 +142,7 @@ class Item(RegisterMixIn):
         EWSElementField('parent_folder_id', field_uri='item:ParentFolderId', value_cls=ParentFolderId,
                         is_read_only=True),
         CharField('item_class', field_uri='item:ItemClass', is_read_only=True),
-        CharField('subject', field_uri='item:Subject'),
+        TextField('subject', field_uri='item:Subject'),
         ChoiceField('sensitivity', field_uri='item:Sensitivity', choices={
             Choice('Normal'), Choice('Personal'), Choice('Private'), Choice('Confidential')
         }, is_required=True, default='Normal'),


### PR DESCRIPTION
### Background
Fixed EWS calendar title length bug where the event wouldn't be created if a user submitted an event with a title >255 characters through Nylas API
https://app.clubhouse.io/nylas/story/18334/event-with-a-title-255-characters-accepted-on-nylas-but-failed-to-create-on-ews-calendar

### Implementation
Changed `'subject'` attribute to `TextField` class instead of `CharField` class in `items.py`

### Tests
Tested local exchangelib by trying to create calendar events with titles >255 on test account
