### PR TITLE
Use `ensure_binary`/`ensure_text` to make data Python 3 compatible

### DIFF
--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -1578,7 +1578,7 @@ class Subscribe(EWSFolderService):
             assert event_type in CONCRETE_EVENT_TYPES
             deduped_event_types.add(event_type.ELEMENT_NAME)
 
-        for event_type_name in deduped_event_types:
+        for event_type_name in sorted(deduped_event_types):
             if event_type_name == 'StatusEvent':
                 continue
             event_type_elem = create_element('t:EventType')

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -21,7 +21,7 @@ import logging
 from sys import stdout
 import traceback
 
-from six import text_type
+from six import ensure_text, text_type
 
 from . import errors
 from .errors import EWSWarning, TransportError, SOAPError, ErrorTimeoutExpired, ErrorBatchProcessingStopped, \
@@ -279,6 +279,7 @@ class EWSService(object):
             for chunk in response.iter_content():
                 if not chunk:
                     continue
+                chunk = ensure_text(chunk)
                 curr_envelope += chunk
                 index = curr_envelope.find(envelope_str)
                 if index == -1:

--- a/exchangelib/services.py
+++ b/exchangelib/services.py
@@ -270,7 +270,7 @@ class EWSService(object):
         elif ftype == 'streaming-response':
             stdout.write(u'STREAMING RESPONSE {} <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<< {}\n'.format(req_id, now))
 
-        stdout.write(PrettyXmlHandler.prettify_xml(xml_str) + b'\n')
+        stdout.write(ensure_text(PrettyXmlHandler.prettify_xml(xml_str) + b'\n'))
 
     def _parse_envelopes(self, response):
         try:

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -22,13 +22,16 @@ from pygments.formatters.terminal import TerminalFormatter
 import requests.auth
 import requests.exceptions
 from requests import Request
-from six import ensure_binary, string_types, text_type
+from six import PY3, ensure_binary, string_types, text_type
 
 from .errors import TransportError, RateLimitError, RedirectError, RelativeRedirect, CASError, UnauthorizedError, \
     InvalidTokenError, ErrorInvalidSchemaVersionForMailboxVersion
 
 time_func = time.time if PY2 else time.monotonic
 log = logging.getLogger(__name__)
+
+if PY3:
+    unicode = str
 
 
 class ParseError(_etree.ParseError):

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -22,16 +22,13 @@ from pygments.formatters.terminal import TerminalFormatter
 import requests.auth
 import requests.exceptions
 from requests import Request
-from six import PY3, ensure_binary, string_types, text_type
+from six import ensure_binary, string_types, text_type
 
 from .errors import TransportError, RateLimitError, RedirectError, RelativeRedirect, CASError, UnauthorizedError, \
     InvalidTokenError, ErrorInvalidSchemaVersionForMailboxVersion
 
 time_func = time.time if PY2 else time.monotonic
 log = logging.getLogger(__name__)
-
-if PY3:
-    unicode = str
 
 
 class ParseError(_etree.ParseError):
@@ -299,8 +296,7 @@ class PrettyXmlHandler(logging.StreamHandler):
     @classmethod
     def prettify_xml(cls, xml_bytes):
         # Re-formats an XML document to a consistent style
-        if isinstance(xml_bytes, unicode):
-            xml_bytes = xml_bytes.encode('utf-8')
+        xml_bytes = ensure_binary(xml_bytes)
         return tostring(
             cls.parse_bytes(xml_bytes),
             xml_declaration=True,

--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -22,7 +22,7 @@ from pygments.formatters.terminal import TerminalFormatter
 import requests.auth
 import requests.exceptions
 from requests import Request
-from six import text_type, string_types
+from six import ensure_binary, string_types, text_type
 
 from .errors import TransportError, RateLimitError, RedirectError, RelativeRedirect, CASError, UnauthorizedError, \
     InvalidTokenError, ErrorInvalidSchemaVersionForMailboxVersion
@@ -512,7 +512,7 @@ Response data: %(xml_response)s
             # Always create a dummy response for logging purposes, in case we fail in the following
             r = DummyResponse(url=url, headers={}, request_headers=headers)
             try:
-                data = data.encode('utf-8')
+                data = ensure_binary(data)
             except UnicodeDecodeError:
                 try:
                     data = data.decode('utf-8').encode('utf-8')


### PR DESCRIPTION
- Added `ensure_binary` and `ensure_text` while looking at `syncback` tests for python 3 compat. Fixing things in exchangelib as they come up in cloud-core.

- Test by setting up this branch locally and running tests in Py2 and Py3 for cloud-core and making sure there is no regression in tests.
- Also added a sort on event_types to make tests more deterministic, as the order was affecting tests in cloud-core.

On master branch tests for exchangelib:

```
Ran 53 tests in 0.473s

FAILED (failures=2, errors=4, skipped=9)
```

On this branch tests:

```
Ran 53 tests in 0.539s

FAILED (failures=2, errors=4, skipped=9)
```

No regressions or test improvements from this commit (🎉 ?)