### PR TITLE
Add ensure_binary to HTTPOAuthAuth header

### DIFF
--- a/exchangelib/util.py
+++ b/exchangelib/util.py
@@ -688,5 +688,5 @@ class HTTPOAuthAuth(requests.auth.AuthBase):  # type: ignore
         self.token = token
 
     def __call__(self, r):
-        r.headers[b'Authorization'] = b'Bearer {}'.format(self.token.encode('utf-8'))
+        r.headers[b'Authorization'] = ensure_binary('Bearer {}'.format(self.token))
         return r


### PR DESCRIPTION
An error came up while tests in Python 3:


```
EWS https://outlook.office365.com/EWS/Exchange.asmx, account BvbnMmxUzYha@eastEST.CoM: Exception in _get_elements: Traceback (most recent call last):
  File "/Users/andrewjung/.pyenv/versions/3.8.5/envs/cloud-core-3.8/lib/python3.8/site-packages/exchangelib/services.py", line 121, in _get_elements
    response = self._get_response_xml(payload=payload)
  File "/Users/andrewjung/.pyenv/versions/3.8.5/envs/cloud-core-3.8/lib/python3.8/site-packages/exchangelib/services.py", line 310, in _get_response_xml
    r, session = post_ratelimited(
  File "/Users/andrewjung/.pyenv/versions/3.8.5/envs/cloud-core-3.8/lib/python3.8/site-packages/exchangelib/util.py", line 523, in post_ratelimited
    r = session.post(url=url,
  File "/Users/andrewjung/.pyenv/versions/3.8.5/envs/cloud-core-3.8/lib/python3.8/site-packages/requests/sessions.py", line 590, in post
    return self.request('POST', url, data=data, json=json, **kwargs)
  File "/Users/andrewjung/.pyenv/versions/3.8.5/envs/cloud-core-3.8/lib/python3.8/site-packages/requests/sessions.py", line 528, in request
    prep = self.prepare_request(req)
  File "/Users/andrewjung/.pyenv/versions/3.8.5/envs/cloud-core-3.8/lib/python3.8/site-packages/requests/sessions.py", line 456, in prepare_request
    p.prepare(
  File "/Users/andrewjung/.pyenv/versions/3.8.5/envs/cloud-core-3.8/lib/python3.8/site-packages/requests/models.py", line 320, in prepare
    self.prepare_auth(auth, url)
  File "/Users/andrewjung/.pyenv/versions/3.8.5/envs/cloud-core-3.8/lib/python3.8/site-packages/requests/models.py", line 551, in prepare_auth
    r = auth(self)
  File "/Users/andrewjung/.pyenv/versions/3.8.5/envs/cloud-core-3.8/lib/python3.8/site-packages/exchangelib/util.py", line 691, in __call__
    r.headers[b'Authorization'] = b'Bearer {}'.format(self.token.encode('utf-8'))
AttributeError: 'bytes' object has no attribute 'format'
```

in `services/api/test/auth/credential_collectors/token_oauth/test_o365_oauth_credential_collector.py::test_single_token_generated_when_given_eas_only_or_ews_only_scopes`