### PR TITLE
Handle more exceptions meaning Exchange server does not have distinguished folder

### DIFF
--- a/exchangelib/folders.py
+++ b/exchangelib/folders.py
@@ -1024,7 +1024,7 @@ class Root(Folder):
             fld = folder_cls(account=self.account, name=folder_cls.DISTINGUISHED_FOLDER_ID, is_distinguished=True)
             fld.test_access()
             return self._folders_map.get(fld.id, fld)  # Use cached instance if available
-        except ErrorFolderNotFound:
+        except (ErrorFolderNotFound, ErrorItemNotFound, ErrorNoPublicFolderReplicaAvailable):
             # The Exchange server does not return a distinguished folder of this type
             pass
 


### PR DESCRIPTION
Not handling these additional exceptions is making accounts not syncing given they run into the issue consistently.

Was discussed with @ecederstrand in https://nylas.slack.com/archives/C01HMHZ69Q9/p1646921211513709

See https://nylas.atlassian.net/browse/SET-3876 for more details.