### PR TITLE
Add message_disposition arg to rsvp methods

### DIFF
--- a/exchangelib/items.py
+++ b/exchangelib/items.py
@@ -611,12 +611,12 @@ class CalendarItem(Item):
         if version:
             self.clean_timezone_fields(version=version)
 
-    def accept(self, **kwargs):
+    def accept(self, message_disposition=SEND_AND_SAVE_COPY, **kwargs):
         return AcceptItem(
             account=self.account,
             reference_item_id=ReferenceItemId(id=self.id, changekey=self.changekey),
             **kwargs
-        ).send()
+        ).send(message_disposition)
 
     def cancel(self, **kwargs):
         return CancelCalendarItem(
@@ -625,19 +625,19 @@ class CalendarItem(Item):
             **kwargs
         ).send()
 
-    def decline(self, **kwargs):
+    def decline(self, message_disposition=SEND_AND_SAVE_COPY, **kwargs):
         return DeclineItem(
             account=self.account,
             reference_item_id=ReferenceItemId(id=self.id, changekey=self.changekey),
             **kwargs
-        ).send()
+        ).send(message_disposition)
 
-    def tentatively_accept(self, **kwargs):
+    def tentatively_accept(self, message_disposition=SEND_AND_SAVE_COPY, **kwargs):
         return TentativelyAcceptItem(
             account=self.account,
             reference_item_id=ReferenceItemId(id=self.id, changekey=self.changekey),
             **kwargs
-        ).send()
+        ).send(message_disposition)
 
     def _update_fieldnames(self):
         update_fields = super(CalendarItem, self)._update_fieldnames()


### PR DESCRIPTION
Similar to the upstream code here:
https://github.com/ecederstrand/exchangelib/blob/master/exchangelib/items/calendar_item.py#L56-L69

Gonna use these methods to fix CUST-1116, but the
message_disposition arg will allow us to not send duplicate email
notifications. We already send our own email with a slightly nicer
subject format.