### PR TITLE
Adds missing timezones

### DIFF
--- a/exchangelib/winzone.py
+++ b/exchangelib/winzone.py
@@ -490,7 +490,14 @@ CLDR_TO_MS_TIMEZONE_MAP = {
 #
 PYTZ_TO_MS_TIMEZONE_MAP = dict(CLDR_TO_MS_TIMEZONE_MAP, **{
     'Asia/Kolkata': 'India Standard Time',
+    'Canada/Pacific': 'America/Vancouver',
+    'EST': 'America/Cancun',
     'UTC': 'UTC',
+    'US/Arizona': 'America/Phoenix',
+    'US/Central': 'America/Chicago',
+    'US/Eastern': 'America/New_York',
+    'US/Mountain': 'America/Denver',
+    'US/Pacific': 'America/Los_Angeles',
     'GMT': 'GMT Standard Time',
 })
 


### PR DESCRIPTION
**Background**
We're seeing the following error for some customers:
`{"Unexpected error type": "No Windows timezone name found for timezone \"Canada/Pacific\""} `
 
**Implementation**
Add this timezone + proactively add other missing timezones:
![image](https://user-images.githubusercontent.com/1754248/195931882-939fa782-65da-46d3-91a4-8646861dc5da.png)

[Jira Ticket
](https://nylas.atlassian.net/browse/SET-4099)

