### PR TITLE
Relax assertion for send operations

### DIFF
--- a/exchangelib/items.py
+++ b/exchangelib/items.py
@@ -289,9 +289,7 @@ class Item(RegisterMixIn):
             items=[self], folder=self.folder, message_disposition=message_disposition,
             send_meeting_invitations=send_meeting_invitations)
         if message_disposition in (SEND_ONLY, SEND_AND_SAVE_COPY):
-            if res:
-                raise ValueError('Got a response in non-save mode')
-            return None
+            return res or None
         if len(res) != 1:
             raise ValueError('Expected result length 1, but got %s' % res)
         if isinstance(res[0], Exception):
@@ -339,9 +337,7 @@ class Item(RegisterMixIn):
             conflict_resolution=conflict_resolution,
             send_meeting_invitations_or_cancellations=send_meeting_invitations)
         if message_disposition == SEND_AND_SAVE_COPY:
-            if res:
-                raise ValueError('Got a response in non-save mode')
-            return None
+            return res or None
         if len(res) != 1:
             raise ValueError('Expected result length 1, but got %s' % res)
         if isinstance(res[0], Exception):
@@ -713,10 +709,7 @@ class Message(Item):
                                send_meeting_invitations=send_meeting_invitations)
             return None
 
-        res = self._create(message_disposition=SEND_ONLY, send_meeting_invitations=send_meeting_invitations)
-        if res:
-            raise ValueError('Unexpected response in send-only mode')
-        return None
+        return self._create(message_disposition=SEND_ONLY, send_meeting_invitations=send_meeting_invitations) or None
 
     def send_and_save(self, update_fields=None, conflict_resolution=AUTO_RESOLVE,
                       send_meeting_invitations=SEND_TO_NONE):
@@ -737,12 +730,10 @@ class Message(Item):
                 self.send(save_copy=False, conflict_resolution=conflict_resolution,
                           send_meeting_invitations=send_meeting_invitations)
             else:
-                res = self._create(
+                return self._create(
                     message_disposition=SEND_AND_SAVE_COPY,
                     send_meeting_invitations=send_meeting_invitations
-                )
-                if res:
-                    raise ValueError('Unexpected response in send-only mode')
+                ) or None
 
     def reply(self, subject, body, to_recipients=None, cc_recipients=None, bcc_recipients=None):
         if not self.account:


### PR DESCRIPTION
Item create/update in send mode sometimes returns a result even though it shouldn't. Relax this assertion.